### PR TITLE
chore: Add linter

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+    "browser": true,
+    "browserify": true,
+    "globalstrict": true,
+    "eqeqeq": true,
+    "eqnull": true,
+    "expr": true,
+    "latedef": "nofunc",
+    "unused": true,
+    "undef": true,
+    "nonew": false,
+    "globals": {
+        "console": true
+    },
+    "validthis": true,
+    "worker": true
+}

--- a/components/test/Position.js
+++ b/components/test/Position.js
@@ -27,8 +27,6 @@
 var test = require('tape');
 var Position = require('../Position');
 
-function noop() {}
-
 test('Position', function(t) {
     t.test('constructor', function(t) {
         var addedComponent = null;

--- a/core/test/Context.js
+++ b/core/test/Context.js
@@ -22,11 +22,12 @@
  * THE SOFTWARE.
  */
 
+/*jshint -W079 */
+
 'use strict';
 
 var test = require('tape');
 var Context = require('../Context');
-var Node = require('../Node');
 var Dispatch = require('../Dispatch');
 
 test('Context', function(t) {

--- a/dom-renderers/events/InputEvent.js
+++ b/dom-renderers/events/InputEvent.js
@@ -22,6 +22,8 @@
  * THE SOFTWARE.
  */
 
+'use strict';
+
 var UIEvent = require('./UIEvent');
 
 function InputEvent(ev) {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test-webgl-renderers": "browserify webgl-renderers/test/*.js | tap-closer | smokestack | tap-spec",
     "test": "npm run test-components && npm run test-core && npm run test-dom-renderables && npm run test-dom-renderers && npm run test-engine && npm run test-math && npm run test-physics && npm run test-polyfills && npm run test-utilities && npm run test-webgl-geometries && npm run test-webgl-materials && npm run test-webgl-renderables && npm run test-webgl-renderers",
     "check": "jscs core dom-renderers physics renderers stylesheets utilities webgl-materials webgl-renderers components dom-renderables engine math polyfills router transitions webgl-geometries webgl-renderables webgl-shaders",
+    "lint": "jshint --reporter node_modules/jshint-stylish/stylish.js .",
     "build": "mkdir dist; browserify index.js --standalone famous | uglifyjs --screw-ie8 -m -c dead_code,sequences,conditionals,booleans,unused,if_return,join_vars,drop_debugger > dist/famous.min.js"
   },
   "repository": {
@@ -30,6 +31,8 @@
   "devDependencies": {
     "browserify": "^9.0.3",
     "jscs": "^1.13.1",
+    "jshint": "^2.7.0",
+    "jshint-stylish": "^1.0.2",
     "smokestack": "^3.2.2",
     "tap-closer": "^1.0.0",
     "tap-spec": "^3.0.0",


### PR DESCRIPTION
See https://github.famo.us/platform/core/pull/141/files

```
➜  mixed-mode git:(develop) ✗ npm run lint       

> famous@0.4.3 lint /Users/alexandergugel/platform/mixed-mode
> jshint --reporter node_modules/jshint-stylish/stylish.js .


dom-renderers/events/EventMap.js
  line 28   col 5    Redefinition of 'Event'.
  line 32   col 5    Redefinition of 'MouseEvent'.
  line 38   col 5    Redefinition of 'event'.

dom-renderers/events/UIEvent.js
  line 27   col 5    Redefinition of 'Event'.

dom-renderers/events/WheelEvent.js
  line 27   col 5    Redefinition of 'MouseEvent'.

dom-renderers/test/DOMRenderer.js
  line 43   col 42   'ev' is defined but never used.
  line 43   col 36   'type' is defined but never used.
  line 43   col 30   'path' is defined but never used.

engine/now.js
  line 27   col 12   'performance' is not defined.

math/Mat33.js
  line 195  col 13   Bad line breaking before '-'.
  line 196  col 13   Bad line breaking before '+'.
  line 221  col 13   Bad line breaking before '-'.
  line 222  col 13   Bad line breaking before '+'.
  line 275  col 13   Bad line breaking before '-'.
  line 276  col 13   Bad line breaking before '+'.

math/Quaternion.js
  line 27   col 5    'Matrix' is defined but never used.
  line 349  col 9    'ww' is defined but never used.

math/Vec3.js
  line 100  col 9    'x' is defined but never used.
  line 122  col 9    'y' is defined but never used.
  line 144  col 9    'z' is defined but never used.

math/test/Vec3.js
  line 293  col 13   'matrix' is defined but never used.

physics/Geometry.js
  line 205  col 28   Missing 'new' prefix when invoking a constructor.
  line 221  col 5    Missing 'new' prefix when invoking a constructor.

physics/bodies/Box.js
  line 30   col 12   Missing 'new' prefix when invoking a constructor.

physics/constraints/Collision.js
  line 264  col 25   Missing 'new' prefix when invoking a constructor.
  line 327  col 25   Missing 'new' prefix when invoking a constructor.
  line 382  col 25   Missing 'new' prefix when invoking a constructor.

physics/constraints/Constraint.js
  line 59   col 43   'options' is defined but never used.
  line 68   col 53   'dt' is defined but never used.
  line 68   col 47   'time' is defined but never used.
  line 77   col 55   'dt' is defined but never used.
  line 77   col 49   'time' is defined but never used.

physics/constraints/collision/ContactManifold.js
  line 95   col 20   Missing 'new' prefix when invoking a constructor.
  line 115  col 5    Missing 'new' prefix when invoking a constructor.
  line 263  col 28   Missing 'new' prefix when invoking a constructor.
  line 281  col 5    Missing 'new' prefix when invoking a constructor.

physics/constraints/collision/ConvexCollisionDetection.js
  line 87   col 25   Missing 'new' prefix when invoking a constructor.
  line 94   col 25   Missing 'new' prefix when invoking a constructor.
  line 97   col 5    Missing 'new' prefix when invoking a constructor.
  line 116  col 12   Missing 'new' prefix when invoking a constructor.
  line 132  col 19   Missing 'new' prefix when invoking a constructor.
  line 208  col 13   Missing 'new' prefix when invoking a constructor.

physics/forces/Force.js
  line 88   col 38   'options' is defined but never used.
  line 97   col 48   'dt' is defined but never used.
  line 97   col 42   'time' is defined but never used.

physics/test/Geometry.spec.js
  line 72   col 13   'x' is defined but never used.
  line 73   col 13   'v' is defined but never used.
  line 84   col 13   'vv' is defined but never used.

physics/test/bodies/ConvexBodyFactory.spec.js
  line 81   col 25   Missing 'new' prefix when invoking a constructor.
  line 82   col 24   Missing 'new' prefix when invoking a constructor.
  line 83   col 21   Missing 'new' prefix when invoking a constructor.
  line 142  col 16   Missing semicolon.
  line 136  col 13   'd' is defined but never used.

physics/test/bodies/Particle.spec.js
  line 196  col 41   Missing semicolon.

physics/test/bodies/Wall.spec.js
  line 49   col 7    Missing semicolon.
  line 29   col 5    'Vec3' is defined but never used.

physics/test/constraints/Curve.spec.js
  line 109  col 48   Missing semicolon.
  line 40   col 33   'z' is defined but never used.

polyfills/animationFrame.js
  line 45   col 13   Bad line breaking before '||'.

polyfills/test/requestAnimationFrame.js
  line 25   col 46   Missing "use strict" statement.
  line 26   col 27   Missing "use strict" statement.
  line 29   col 5    Missing "use strict" statement.
  line 30   col 24   Missing "use strict" statement.

renderers/Compositor.js
  line 44   col 48   'ev' is defined but never used.

renderers/Context.js
  line 86   col 2    Missing semicolon.
  line 109  col 9    'pointer' is defined but never used.
  line 110  col 9    'parentEl' is defined but never used.
  line 111  col 9    'element' is defined but never used.
  line 112  col 9    'id' is defined but never used.

renderers/test/Compositor.js
  line 77   col 29   ['body'] is better written in dot notation.
  line 78   col 29   ['body'] is better written in dot notation.
  line 154  col 14   Missing semicolon.
  line 214  col 41   'deep' is defined but never used.

renderers/test/Context.js
  line 52   col 13   'dummyRenderers' is defined but never used.
  line 53   col 13   'drawCallsIssued' is defined but never used.

renderers/test/TestingWindow.js
  line 36   col 2    Missing semicolon.
  line 49   col 2    Missing semicolon.
  line 80   col 9    'child' is defined but never used.
  line 90   col 36   'cb' is defined but never used.
  line 90   col 32   'ev' is defined but never used.

renderers/test/ThreadManager.js
  line 60   col 47   Missing semicolon.
  line 63   col 48   Missing semicolon.

router/test/Router.js
  line 33   col 14   Missing 'new' prefix when invoking a constructor.
  line 38   col 22   Missing 'new' prefix when invoking a constructor.
  line 58   col 22   Missing 'new' prefix when invoking a constructor.
  line 126  col 22   Missing 'new' prefix when invoking a constructor.
  line 142  col 28   Missing 'new' prefix when invoking a constructor.
  line 171  col 22   Missing 'new' prefix when invoking a constructor.
  line 185  col 55   Missing semicolon.
  line 188  col 22   Missing 'new' prefix when invoking a constructor.

router/test/bind-polyfill.js
  line 40   col 18   Bad line breaking before '?'.
  line 46   col 28   A constructor name should start with an uppercase letter.

transitions/Transitionable.js
  line 196  col 17   'resx' is defined but never used.
  line 196  col 23   'resy' is defined but never used.
  line 196  col 29   'resz' is defined but never used.
  line 196  col 35   'resw' is defined but never used.

transitions/test/Transitionable.js
  line 237  col 20   Missing semicolon.

utilities/CallbackStore.js
  line 53   col 6    Missing semicolon.

utilities/Color.js
  line 43   col 2    Unnecessary semicolon.
  line 361  col 16   'colorNames' was used before it was defined.

utilities/MethodStore.js
  line 36   col 2    Missing semicolon.
  line 45   col 2    Missing semicolon.

utilities/ObjectManager.js
  line 55   col 6    Missing semicolon.
  line 61   col 6    Missing semicolon.

utilities/strip.js
  line 48   col 14   'Symbol' is not defined.

utilities/test/Color.js
  line 31   col 5    '_now' is defined but never used.
  line 477  col 17   'color' is defined but never used.

utilities/test/strip.js
  line 25   col 1    Missing semicolon.

webgl-geometries/GeometryHelper.js
  line 95   col 2    Missing semicolon.
  line 176  col 10   Don't make functions within a loop.
  line 184  col 14   Don't make functions within a loop.
  line 252  col 10   Don't make functions within a loop.
  line 282  col 13   'out' is already defined.
  line 314  col 13   'out' is already defined.
  line 350  col 13   'out' is already defined.
  line 373  col 13   'out' is already defined.
  line 399  col 6    Unnecessary semicolon.
  line 413  col 16   'i' is already defined.
  line 490  col 13   'out' is already defined.
  line 515  col 16   'i' is already defined.
  line 63   col 24   'result' is defined but never used.
  line 112  col 9    'vertexThree' is defined but never used.
  line 113  col 9    'vertexTwo' is defined but never used.
  line 114  col 9    'vertexOne' is defined but never used.
  line 118  col 9    'start' is defined but never used.
  line 119  col 9    'end' is defined but never used.
  line 167  col 9    'abc' is defined but never used.
  line 351  col 9    'vertex' is defined but never used.
  line 491  col 9    'face' is defined but never used.
  line 492  col 9    'j' is defined but never used.

webgl-geometries/OBJLoader.js
  line 25   col 53   Missing "use strict" statement.
  line 26   col 49   Missing "use strict" statement.
  line 41   col 2    Missing "use strict" statement.
  line 56   col 5    Missing "use strict" statement.
  line 70   col 5    Missing "use strict" statement.
  line 73   col 1    Missing "use strict" statement.
  line 88   col 5    Missing "use strict" statement.
  line 88   col 57   Missing "use strict" statement.
  line 95   col 5    Missing "use strict" statement.
  line 111  col 5    Missing "use strict" statement.
  line 111  col 14   'text' is already defined.
  line 111  col 30   Missing "use strict" statement.
  line 113  col 33   Missing "use strict" statement.
  line 115  col 27   Missing "use strict" statement.
  line 116  col 26   Missing "use strict" statement.
  line 117  col 25   Missing "use strict" statement.
  line 119  col 21   Missing "use strict" statement.
  line 120  col 23   Missing "use strict" statement.
  line 121  col 22   Missing "use strict" statement.
  line 123  col 23   Missing "use strict" statement.
  line 124  col 14   Missing "use strict" statement.
  line 125  col 13   Missing "use strict" statement.
  line 127  col 30   Missing "use strict" statement.
  line 199  col 13   Missing "use strict" statement.
  line 245  col 13   Missing "use strict" statement.
  line 285  col 13   Missing "use strict" statement.
  line 286  col 9    Missing "use strict" statement.
  line 286  col 9    Missing "use strict" statement.
  line 287  col 5    Missing "use strict" statement.
  line 287  col 5    Missing "use strict" statement.
  line 287  col 5    Missing "use strict" statement.
  line 287  col 5    Missing "use strict" statement.
  line 289  col 5    Missing "use strict" statement.
  line 296  col 6    Missing "use strict" statement.
  line 310  col 5    Missing "use strict" statement.
  line 317  col 5    Missing "use strict" statement.
  line 322  col 6    Missing "use strict" statement.
  line 323  col 2    Unnecessary semicolon.
  line 337  col 5    Missing "use strict" statement.
  line 337  col 60   Missing "use strict" statement.
  line 358  col 5    Missing "use strict" statement.
  line 358  col 24   Missing "use strict" statement.
  line 359  col 20   Missing "use strict" statement.
  line 360  col 25   Missing "use strict" statement.
  line 361  col 24   Missing "use strict" statement.
  line 363  col 25   Missing "use strict" statement.
  line 365  col 22   Missing "use strict" statement.
  line 366  col 20   Missing "use strict" statement.
  line 367  col 22   Missing "use strict" statement.
  line 369  col 25   Missing "use strict" statement.
  line 369  col 25   Too many errors. (85% scanned).

webgl-geometries/primitives/Box.js
  line 55   col 17   'options' is already defined.
  line 89   col 2    Unnecessary semicolon.

webgl-geometries/primitives/Circle.js
  line 43   col 18   'options' is already defined.
  line 94   col 16   'detail' is already defined.
  line 74   col 13   'z' is defined but never used.

webgl-geometries/primitives/Cylinder.js
  line 44   col 18   'options' is already defined.
  line 87   col 2    Missing semicolon.

webgl-geometries/primitives/GeodesicSphere.js
  line 59   col 17   'options' is already defined.

webgl-geometries/primitives/Icosahedron.js
  line 45   col 9    'geometry' is defined but never used.
  line 46   col 9    'detail' is defined but never used.

webgl-geometries/primitives/ParametricCone.js
  line 43   col 18   'options' is already defined.
  line 86   col 2    Missing semicolon.

webgl-geometries/primitives/Plane.js
  line 43   col 17   'options' is already defined.
  line 58   col 29   A trailing decimal point can be confused with a dot: '2.'.
  line 58   col 39   A leading decimal point can be confused with a dot: '.5'.
  line 58   col 53   A leading decimal point can be confused with a dot: '.5'.
  line 74   col 17   'normals' is already defined.
  line 84   col 2    Unnecessary semicolon.

webgl-geometries/primitives/Tetrahedron.js
  line 45   col 9    'geometry' is defined but never used.

webgl-geometries/primitives/Torus.js
  line 44   col 18   'options' is already defined.
  line 80   col 2    Missing semicolon.

webgl-geometries/primitives/Triangle.js
  line 43   col 18   'options' is already defined.

webgl-geometries/test/DynamicGeometry.spec.js
  line 213  col 53   Missing semicolon.
  line 227  col 37   Missing semicolon.
  line 241  col 45   Missing semicolon.

webgl-geometries/test/GeometryHelper.spec.js
  line 48   col 10   Missing semicolon.
  line 128  col 14   Confusing use of '!'.
  line 129  col 14   Confusing use of '!'.
  line 130  col 14   Confusing use of '!'.
  line 131  col 14   Confusing use of '!'.
  line 132  col 14   Confusing use of '!'.
  line 133  col 14   Confusing use of '!'.
  line 150  col 21   'indices' is already defined.
  line 236  col 17   Bad line breaking before '&&'.
  line 237  col 17   Bad line breaking before '&&'.
  line 298  col 15   'range' is already defined.
  line 54   col 13   'buffers' is defined but never used.
  line 119  col 40   'i' is defined but never used.

webgl-geometries/test/OBJLoader.spec.js
  line 83   col 9    'OBJ' was used before it was defined.
  line 28   col 5    'Vec3' is defined but never used.
  line 52   col 48   'res' is defined but never used.

webgl-geometries/test/Primitives.spec.js
  line 41   col 2    Missing semicolon.

webgl-materials/Material.js
  line 155  col 10   Redefinition of 'name'.
  line 211  col 10   'typeofConst' is defined but never used.

webgl-materials/TextureRegistry.js
  line 76   col 2    Missing semicolon.

webgl-materials/test/TextureRegistry.spec.js
  line 36   col 38   ['myFirstTexture'] is better written in dot notation.

webgl-renderables/Mesh.js
  line 281  col 19   'glossiness' is already defined.
  line 118  col 21   'bufferIndex' is defined but never used.
  line 267  col 50   'materialExpression' is defined but never used.
  line 356  col 64   'materialExpression' is defined but never used.
  line 505  col 72   'properties' is defined but never used.
  line 505  col 63   'methods' is defined but never used.
  line 505  col 54   'UIEvent' is defined but never used.
  line 525  col 9    'key' is defined but never used.
  line 526  col 9    'i' is defined but never used.
  line 527  col 9    'len' is defined but never used.

webgl-renderables/lights/AmbientLight.js
  line 44   col 2    Unnecessary semicolon.

webgl-renderables/lights/Light.js
  line 43   col 2    Unnecessary semicolon.
  line 83   col 46   'option' is defined but never used.

webgl-renderables/lights/PointLight.js
  line 43   col 2    Unnecessary semicolon.

webgl-renderables/test/AmbientLight.js
  line 95   col 13   'light' is not defined.
  line 33   col 5    '_now' is defined but never used.

webgl-renderables/test/Light.js
  line 33   col 5    '_now' is defined but never used.

webgl-renderables/test/Mesh.js
  line 416  col 67   Missing semicolon.
  line 458  col 67   Missing semicolon.
  line 33   col 5    '_now' is defined but never used.
  line 34   col 27   'geometry' is defined but never used.

webgl-renderables/test/MockDispatch.js
  line 50   col 82   Missing semicolon.

webgl-renderables/test/PointLight.js
  line 95   col 13   'light' is not defined.
  line 33   col 5    '_now' is defined but never used.

webgl-renderers/BufferRegistry.js
  line 135  col 16   'k' is already defined.

webgl-renderers/Debug.js
  line 47   col 2    Missing semicolon.
  line 62   col 6    Missing semicolon.
  line 76   col 13   Bad line breaking before '+'.
  line 77   col 13   Bad line breaking before '+'.
  line 78   col 13   Bad line breaking before '+'.
  line 79   col 13   Bad line breaking before '+'.
  line 80   col 13   Bad line breaking before '+'.
  line 81   col 13   Bad line breaking before '+'.
  line 82   col 13   Bad line breaking before '+'.
  line 99   col 83   Missing semicolon.

webgl-renderers/Program.js
  line 161  col 16   'k' is already defined.
  line 168  col 16   'k' is already defined.
  line 177  col 16   Expected '===' and instead saw '=='.
  line 183  col 16   Expected '===' and instead saw '=='.
  line 189  col 16   Expected '===' and instead saw '=='.
  line 195  col 16   Expected '===' and instead saw '=='.
  line 216  col 9    'vsChunkDefines' is defined but never used.
  line 217  col 9    'vsChunkApplies' is defined but never used.
  line 218  col 9    'fsChunkDefines' is defined but never used.
  line 219  col 9    'fsChunkApplies' is defined but never used.
  line 226  col 9    'material' is defined but never used.
  line 228  col 9    'chunk' is defined but never used.
  line 375  col 9    'flag' is defined but never used.

webgl-renderers/Texture.js
  line 144  col 53   Expected '===' and instead saw '=='.
  line 165  col 9    Bad line breaking before '&&'.
  line 166  col 2    Unnecessary semicolon.
  line 163  col 10   'isPowerOfTwo' is defined but never used.

webgl-renderers/TextureManager.js
  line 64   col 2    Missing semicolon.
  line 121  col 10   Missing semicolon.
  line 125  col 2    Missing semicolon.
  line 170  col 2    Missing semicolon.

webgl-renderers/WebGLRenderer.js
  line 174  col 38   Did you mean to return a conditional instead of an assignment?
  line 201  col 37   Did you mean to return a conditional instead of an assignment?
  line 241  col 43   Did you mean to return a conditional instead of an assignment?
  line 391  col 18   'material' is already defined.
  line 664  col 15   'i' is already defined.
  line 717  col 19   Expected '!==' and instead saw '!='.
  line 717  col 52   Expected '!==' and instead saw '!='.
  line 732  col 2    Unnecessary semicolon.
  line 748  col 81   Unreachable 'break' after 'throw'.
  line 750  col 89   Unreachable 'break' after 'throw'.
  line 752  col 81   Unreachable 'break' after 'throw'.
  line 754  col 71   Unreachable 'break' after 'throw'.
  line 758  col 2    Unnecessary semicolon.
  line 797  col 24   Expected '===' and instead saw '=='.
  line 27   col 5    'Texture' is defined but never used.
  line 29   col 5    'Buffer' is defined but never used.
  line 708  col 10   'renderOffscreen' is defined but never used.
  line 225  col 9    'geometry' is defined but never used.

webgl-renderers/compileMaterial.js
  line 124  col 20   Expected '===' and instead saw '=='.
  line 123  col 34   'arrayToVec' is not defined.
  line 132  col 10   '_arrayToVec' is defined but never used.
  line 48   col 41   'depth' is defined but never used.

webgl-renderers/test/Buffer.spec.js
  line 45   col 19   'buffer' is already defined.
  line 34   col 12   'spacing' is defined but never used.
  line 45   col 12   'buffer' is defined but never used.
  line 56   col 12   'spacing' is defined but never used.

webgl-renderers/test/Program.spec.js
  line 32   col 5    '_now' is defined but never used.

webgl-renderers/test/Texture.spec.js
  line 58   col 123  Missing semicolon.
  line 75   col 122  Missing semicolon.
  line 131  col 162  Missing semicolon.
  line 102  col 13   'returned' is defined but never used.

webgl-renderers/test/checkerBoard.spec.js
  line 28   col 5    'TestingContext' is defined but never used.

webgl-renderers/test/helpers/ContextWebGL.js
  line 164  col 2    Missing "use strict" statement.
  line 167  col 5    Missing "use strict" statement.
  line 167  col 16   Missing "use strict" statement.
  line 171  col 5    Missing "use strict" statement.
  line 171  col 14   Missing "use strict" statement.
  line 175  col 5    Missing "use strict" statement.
  line 175  col 16   Missing "use strict" statement.
  line 179  col 5    Missing "use strict" statement.
  line 179  col 10   Missing "use strict" statement.
  line 180  col 29   Missing "use strict" statement.
  line 182  col 16   'i' is already defined.
  line 190  col 45   Missing "use strict" statement.
  line 192  col 9    Missing "use strict" statement.
  line 192  col 10   Don't make functions within a loop.
  line 198  col 5    Missing "use strict" statement.
  line 200  col 34   Missing "use strict" statement.

webgl-renderers/test/radixSort.spec.js
  line 31   col 48   A leading decimal point can be confused with a dot: '.5'.
  line 31   col 72   Missing semicolon.
  line 33   col 71   Missing semicolon.
  line 35   col 31   Unnecessary semicolon.
  line 35   col 5    'assert' is not defined.
  line 36   col 5    'assert' is not defined.
  line 29   col 28   't' is defined but never used.

  ✖  67 errors
  ⚠  271 warnings


npm ERR! Darwin 14.1.0
npm ERR! argv "node" "/usr/local/bin/npm" "run" "lint"
npm ERR! node v0.12.0
npm ERR! npm  v2.8.3
npm ERR! code ELIFECYCLE
npm ERR! famous@0.4.3 lint: `jshint --reporter node_modules/jshint-stylish/stylish.js .`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the famous@0.4.3 lint script 'jshint --reporter node_modules/jshint-stylish/stylish.js .'.
npm ERR! This is most likely a problem with the famous package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     jshint --reporter node_modules/jshint-stylish/stylish.js .
npm ERR! You can get their info via:
npm ERR!     npm owner ls famous
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/alexandergugel/platform/mixed-mode/npm-debug.log
```
