### PR TITLE
Component-Math: Fix typos

### DIFF
--- a/components/GestureHandler.js
+++ b/components/GestureHandler.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -157,7 +157,7 @@ GestureHandler.prototype.on = function on(ev, cb) {
 };
 
 /**
- * Trigger gestures in the order they were requested, if they occured.
+ * Trigger gestures in the order they were requested, if they occurred.
  *
  * @method triggerGestures
  */

--- a/core/Node.js
+++ b/core/Node.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -202,7 +202,7 @@ Node.prototype.emit = function emit (event, payload) {
     return this;
 };
 
-// THIS WILL BE DEPRICATED
+// THIS WILL BE DEPRECATED
 Node.prototype.sendDrawCommand = function sendDrawCommand (message) {
     this._globalUpdater.message(message);
     return this;
@@ -341,7 +341,7 @@ Node.prototype.getUpdater = function getUpdater () {
  *
  * @method isMounted
  *
- * @return {Boolean}    Boolean indicating weather the node is mounted or not.
+ * @return {Boolean}    Boolean indicating whether the node is mounted or not.
  */
 Node.prototype.isMounted = function isMounted () {
     return this.value.showState.mounted;
@@ -352,7 +352,7 @@ Node.prototype.isMounted = function isMounted () {
  *
  * @method isShown
  *
- * @return {Boolean}    Boolean indicating weather the node is visible
+ * @return {Boolean}    Boolean indicating whether the node is visible
  *                      ("shown") or not.
  */
 Node.prototype.isShown = function isShown () {
@@ -495,7 +495,7 @@ Node.prototype.removeChild = function removeChild (child) {
  *
  * @method addComponent
  *
- * @param {Object} component    An component to be added.
+ * @param {Object} component    A component to be added.
  * @return {Number} index       The index at which the component has been
  *                              registered. Indices aren't necessarily
  *                              consecutive.
@@ -518,12 +518,12 @@ Node.prototype.addComponent = function addComponent (component) {
 
 /**
  * @method  getComponent
- *  
- * @param  {Number} index   Index at which the component has been regsitered
+ *
+ * @param  {Number} index   Index at which the component has been registered
  *                          (using `Node#addComponent`).
  * @return {*}              The component registered at the passed in index (if
  *                          any).
- */ 
+ */
 Node.prototype.getComponent = function getComponent (index) {
     return this._components[index];
 };
@@ -533,7 +533,7 @@ Node.prototype.getComponent = function getComponent (index) {
  *
  * @method removeComponent
  *
- * @param  {Object} component   An component that has previously been added
+ * @param  {Object} component   A component that has previously been added
  *                              using @{@link addComponent}.
  */
 Node.prototype.removeComponent = function removeComponent (component) {
@@ -858,7 +858,7 @@ Node.prototype.setOpacity = function setOpacity (val) {
 };
 
 /**
- * Sets the size mode being used for determining the nodes final width, height
+ * Sets the size mode being used for determining the node's final width, height
  * and depth.
  * Size modes are a way to define the way the node's size is being calculated.
  * Size modes are enums set on the @{@link Size} constructor (and aliased on
@@ -866,7 +866,7 @@ Node.prototype.setOpacity = function setOpacity (val) {
  *
  * @example
  * node.setSizeMode(Node.RELATIVE_SIZE, Node.ABSOLUTE_SIZE, Node.ABSOLUTE_SIZE);
- * // Instead of null, any proporional height or depth can be passed in, since
+ * // Instead of null, any proportional height or depth can be passed in, since
  * // it would be ignored in any case.
  * node.setProportionalSize(0.5, null, null);
  * node.setAbsoluteSize(null, 100, 200);
@@ -883,7 +883,7 @@ Node.prototype.setOpacity = function setOpacity (val) {
 Node.prototype.setSizeMode = function setSizeMode (x, y, z) {
     var vec3 = this.value.size.sizeMode;
     var propogate = false;
-    
+
     if (x != null) propogate = this._resolveSizeMode(vec3, 0, x) || propogate;
     if (y != null) propogate = this._resolveSizeMode(vec3, 1, y) || propogate;
     if (z != null) propogate = this._resolveSizeMode(vec3, 2, z) || propogate;
@@ -964,7 +964,7 @@ Node.prototype.setProportionalSize = function setProportionalSize (x, y, z) {
 };
 
 /**
- * Differential sizing can be used to add or subtract an absolute size from a
+ * Differential sizing can be used to add or subtract an absolute size from an
  * otherwise proportionally sized node.
  * E.g. a differential width of `-10` and a proportional width of `0.5` is
  * being interpreted as setting the node's size to 50% of its parent's width
@@ -1004,7 +1004,7 @@ Node.prototype.setDifferentialSize = function setDifferentialSize (x, y, z) {
 };
 
 /**
- * Sets the nodes size in pixels, independent of its parent.
+ * Sets the node's size in pixels, independent of its parent.
  *
  * @method setAbsoluteSize
  *
@@ -1078,7 +1078,7 @@ Node.prototype._sizeChanged = function _sizeChanged (size) {
     }
 };
 
-// DEPRICATE
+// DEPRECATE
 Node.prototype.getFrame = function getFrame () {
     return this._globalUpdater.getFrame();
 };

--- a/core/Scene.js
+++ b/core/Scene.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,7 +31,7 @@ var Node = require('./Node');
 var Size = require('./Size');
 
 /**
- * Scene is the bottom of the scene graph. It is it's own
+ * Scene is the bottom of the scene graph. It is its own
  * parent and provides the global updater to the scene graph.
  *
  * @class Scene
@@ -52,20 +52,20 @@ function Scene (selector, updater) {
 
     this._updater = updater; // The updater that will both
                              // send messages to the renderers
-                             // and update dirty nodes 
+                             // and update dirty nodes
 
     this._dispatch = new Dispatch(this); // instantiates a dispatcher
                                          // to send events to the scene
                                          // graph below this context
-    
+
     this._selector = selector; // reference to the DOM selector
-                               // that represents the elemnent
+                               // that represents the element
                                // in the dom that this context
                                // inhabits
 
     this.onMount(this, selector); // Mount the context to itself
                                   // (it is its own parent)
-    
+
     this._updater                  // message a request for the dom
         .message('NEED_SIZE_FOR')  // size of the context so that
         .message(selector);        // the scene graph has a total size
@@ -120,8 +120,8 @@ Scene.prototype.onReceive = function onReceive (event, payload) {
     // and the context would receive its size the same way that any render size
     // component receives its size.
     if (event === 'CONTEXT_RESIZE') {
-        
-        if (payload.length < 2) 
+
+        if (payload.length < 2)
             throw new Error(
                     'CONTEXT_RESIZE\'s payload needs to be at least a pair' +
                     ' of pixel sizes'

--- a/core/Size.js
+++ b/core/Size.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -39,8 +39,8 @@ Size.RENDER = 2;
 Size.DEFAULT = Size.RELATIVE;
 
 /**
- * fromSpecWithParent takes the parent node's size, the target nodes spec,
- * and a target array to write to. Using the node's size mode it calculates 
+ * fromSpecWithParent takes the parent node's size, the target node's spec,
+ * and a target array to write to. Using the node's size mode it calculates
  * a final size for the node from the node's spec. Returns whether or not
  * the final size has changed from its last value.
  *
@@ -76,7 +76,7 @@ Size.prototype.fromSpecWithParent = function fromSpecWithParent (parentSize, nod
                         prev = target[i];
                         target[i] = target[i] < candidate || target[i] === 0 ? candidate : target[i];
                     }
-                }                    
+                }
                 break;
         }
         changed = changed || prev !== target[i];

--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -94,9 +94,9 @@ function DOMElement (node, options) {
 
     this._callbacks = new CallbackStore();
 
-    
+
     var key;
-    
+
     for (key in this.constructor.DEFAULT_STYLES) {
         this.setProperty(key, this.constructor.DEFAULT_STYLES[key]);
     }
@@ -170,7 +170,7 @@ DOMElement.prototype.onUpdate = function onUpdate () {
             node.sendDrawCommand(node.getLocation());
             this._requestRenderSize = false;
         }
- 
+
     }
 
     this._requestingUpdate = false;
@@ -356,8 +356,8 @@ DOMElement.prototype.onOpacityChange = function onOpacityChange (opacity) {
 
 /**
  * Method to be invoked by the node as soon as a new UIEvent is being added.
- * This results into an `ADD_EVENT_LISTENER` command being send.
- * 
+ * This results into an `ADD_EVENT_LISTENER` command being sent.
+ *
  * @param  {String} UIEvent     UIEvent to be subscribed to (e.g. `click`).
  */
 DOMElement.prototype.onAddUIEvent = function onAddUIEvent (UIEvent) {

--- a/engine/ContainerEngine.js
+++ b/engine/ContainerEngine.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,7 +31,7 @@ var now = require('./now');
  * `update` method invocations to the refresh rate of the screen.
  * Does not normalize the high resolution timestamp when being consecutively
  * started and stopped.
- * 
+ *
  * @class ContainerEngine
  * @constructor
  */
@@ -63,7 +63,7 @@ ContainerEngine.prototype._onWindowMessage = function _onWindowMessage(ev) {
  *
  * @method start
  * @chainable
- * 
+ *
  * @return {ContainerEngine} this
  */
 ContainerEngine.prototype.start = function start() {
@@ -77,7 +77,7 @@ ContainerEngine.prototype.start = function start() {
  *
  * @method stop
  * @chainable
- * 
+ *
  * @return {ContainerEngine} this
  */
 ContainerEngine.prototype.stop = function stop() {
@@ -90,7 +90,7 @@ ContainerEngine.prototype.stop = function stop() {
  * Determines whether the ContainerEngine is currently running or not.
  *
  * @method isRunning
- * 
+ *
  * @return {Boolean}    boolean value indicating whether the ContainerEngine is
  *                      currently running or not
  */
@@ -103,8 +103,8 @@ ContainerEngine.prototype.isRunning = function isRunning() {
  *
  * @method step
  * @chainable
- * 
- * @param  {Number} time high resolution timstamp used for invoking the
+ *
+ * @param  {Number} time high resolution timestamp used for invoking the
  *                       `update` method on all registered objects
  * @return {ContainerEngine}      this
  */
@@ -116,12 +116,12 @@ ContainerEngine.prototype.step = function step (time) {
 };
 
 /**
- * Registeres an updateable object which `update` method should be invoked on
+ * Registers an updateable object which `update` method should be invoked on
  * every paint, starting on the next paint (assuming the ContainerEngine is running).
  *
  * @method update
  * @chainable
- * 
+ *
  * @param  {Object} updateable          object to be updated
  * @param  {Function} updateable.update update function to be called on the
  *                                      registered object
@@ -140,7 +140,7 @@ ContainerEngine.prototype.update = function update(updateable) {
  *
  * @method noLongerUpdate
  * @chainable
- * 
+ *
  * @param  {Object} updateable          updateable object previously
  *                                      registered using `update`
  * @return {ContainerEngine}                     this

--- a/engine/Engine.js
+++ b/engine/Engine.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -56,7 +56,7 @@ if (typeof document !== 'undefined') {
  * `update` method invocations to the refresh rate of the screen. Manages
  * the `requestAnimationFrame`-loop by normalizing the passed in timestamp
  * when switching tabs.
- * 
+ *
  * @class Engine
  * @constructor
  */
@@ -94,7 +94,7 @@ function Engine() {
  *
  * @method start
  * @chainable
- * 
+ *
  * @return {Engine} this
  */
 Engine.prototype.start = function start() {
@@ -112,7 +112,7 @@ Engine.prototype.start = function start() {
  *
  * @method stop
  * @chainable
- * 
+ *
  * @return {Engine} this
  */
 Engine.prototype.stop = function stop() {
@@ -129,7 +129,7 @@ Engine.prototype.stop = function stop() {
  * Determines whether the Engine is currently running or not.
  *
  * @method isRunning
- * 
+ *
  * @return {Boolean}    boolean value indicating whether the Engine is
  *                      currently running or not
  */
@@ -142,8 +142,8 @@ Engine.prototype.isRunning = function isRunning() {
  *
  * @method step
  * @chainable
- * 
- * @param  {Number} time high resolution timstamp used for invoking the
+ *
+ * @param  {Number} time high resolution timestamp used for invoking the
  *                       `update` method on all registered objects
  * @return {Engine}      this
  */
@@ -160,8 +160,8 @@ Engine.prototype.step = function step (time) {
  *
  * @method loop
  * @chainable
- * 
- * @param  {Number} time high resolution timstamp used for invoking the
+ *
+ * @param  {Number} time high resolution timestamp used for invoking the
  *                       `update` method on all registered objects
  * @return {Engine}      this
  */
@@ -172,12 +172,12 @@ Engine.prototype.loop = function loop(time) {
 };
 
 /**
- * Registeres an updateable object which `update` method should be invoked on
+ * Registers an updateable object which `update` method should be invoked on
  * every paint, starting on the next paint (assuming the Engine is running).
  *
  * @method update
  * @chainable
- * 
+ *
  * @param  {Object} updateable          object to be updated
  * @param  {Function} updateable.update update function to be called on the
  *                                      registered object
@@ -196,7 +196,7 @@ Engine.prototype.update = function update(updateable) {
  *
  * @method noLongerUpdate
  * @chainable
- * 
+ *
  * @param  {Object} updateable          updateable object previously
  *                                      registered using `update`
  * @return {Engine}                     this


### PR DESCRIPTION
I'm checking in alphabetical order - This is Component to Math. 
My text editor also automatically gets rid of trailing spaces. Please let me know if this is a problem/not something you want.