### PR TITLE
Add ContainerMode to UIManager to avoid additional build step

### DIFF
--- a/core/Commands.js
+++ b/core/Commands.js
@@ -67,11 +67,11 @@ var Commands = {
 
     FAMOUS: 36,
     CONTAINER_EVENT: 37,
-
     CONTAINER: 38,
     REQUEST_SIZE: 39,
+    SEND_SIZE: 40,
 
-    UNSUBSCRIBE: 40,
+    UNSUBSCRIBE: 41,
 
     prettyPrint: function (buffer, start, count) {
         var callback;

--- a/core/Commands.js
+++ b/core/Commands.js
@@ -64,7 +64,12 @@ var Commands = {
     READY: 33,
     ALLOW_DEFAULT: 34,
     PREVENT_DEFAULT: 35,
-    UNSUBSCRIBE: 36,
+
+    FAMOUS: 36,
+    CONTAINER_EVENT: 37,
+
+    UNSUBSCRIBE: 38,
+
     prettyPrint: function (buffer, start, count) {
         var callback;
         start = start ? start : 0;
@@ -85,7 +90,7 @@ var commandPrinters = [];
 
 commandPrinters[Commands.INIT_DOM] = function init_dom (buffer, data) {
     data.result += data.i + '. INIT_DOM\n    tagName: ' + buffer[++data.i] + '\n\n';
-}; 
+};
 
 commandPrinters[Commands.DOM_RENDER_SIZE] = function dom_render_size (buffer, data) {
     data.result += data.i + '. DOM_RENDER_SIZE\n    selector: ' + buffer[++data.i] + '\n\n';
@@ -210,4 +215,3 @@ commandPrinters[Commands.NEED_SIZE_FOR] = function need_size_for (buffer, data) 
 };
 
 module.exports = Commands;
-

--- a/core/Commands.js
+++ b/core/Commands.js
@@ -68,7 +68,10 @@ var Commands = {
     FAMOUS: 36,
     CONTAINER_EVENT: 37,
 
-    UNSUBSCRIBE: 38,
+    CONTAINER: 38,
+    REQUEST_SIZE: 39,
+
+    UNSUBSCRIBE: 40,
 
     prettyPrint: function (buffer, start, count) {
         var callback;

--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -231,8 +231,10 @@ FamousEngine.prototype.handleMessage = function handleMessage (messages) {
                 this.handleFrame(messages);
                 break;
             case Commands.SEND_SIZE:
-                var containerWidth = messages.shift();
-                var containerHeight = messages.shift();
+                // var containerWidth = messages.shift();
+                // var containerHeight = messages.shift();
+                messages.shift();
+                messages.shift();
                 // TODO
                 break;
             default:

--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -230,6 +230,11 @@ FamousEngine.prototype.handleMessage = function handleMessage (messages) {
             case Commands.FRAME:
                 this.handleFrame(messages);
                 break;
+            case Commands.SEND_SIZE:
+                var containerWidth = messages.shift();
+                var containerHeight = messages.shift();
+                // TODO
+                break;
             default:
                 throw new Error('received unknown command: ' + command);
         }

--- a/render-loops/ContainerLoop.js
+++ b/render-loops/ContainerLoop.js
@@ -31,8 +31,9 @@ var now = require('./now');
  * `update` method invocations to the refresh rate of the screen.
  * Does not normalize the high resolution timestamp when being consecutively
  * started and stopped.
- * 
+ *
  * @class ContainerLoop
+ * @deprecated @link{UIManager} automatically handles received window messages.
  */
 function ContainerLoop() {
     this._updates = [];

--- a/renderers/UIManager.js
+++ b/renderers/UIManager.js
@@ -254,6 +254,7 @@ UIManager.prototype.exitContainerMode = function exitContainerMode () {
  */
 UIManager.prototype._handleWindowMessage = function _handleWindowMessage (message) {
     var windowCommands = message.data;
+
     if (windowCommands && windowCommands.constructor === Array && windowCommands[0] === Commands.FAMOUS) {
         this.enterContainerMode(message);
 

--- a/renderers/UIManager.js
+++ b/renderers/UIManager.js
@@ -226,7 +226,7 @@ UIManager.prototype.requestContainerSize = function requestContainerSize() {
     }
 
     this._container.postMessage([Commands.CONTAINER, Commands.REQUEST_SIZE], '*');
-}
+};
 
 /**
  * Exits from container mode. Starts the render loop if possible, but won't

--- a/renderers/UIManager.js
+++ b/renderers/UIManager.js
@@ -71,7 +71,7 @@ function UIManager (thread, compositor, renderLoop) {
         if (message[0] === Commands.ENGINE) {
             if (!_this._renderLoop) {
                 console.error(
-                    'Can not process ENGINE commands since no orender loop' +
+                    'Can not process ENGINE commands since no render loop' +
                     'is available.'
                 );
                 return;
@@ -229,8 +229,11 @@ UIManager.prototype.exitContainerMode = function exitContainerMode () {
  */
 UIManager.prototype._handleWindowMessage = function _handleWindowMessage (message) {
     var windowCommands = message.data;
-    if (windowCommands && windowCommands.constructor === Array) {
+    if (windowCommands && windowCommands.constructor === Array && windowCommands[0] === Commands.FAMOUS) {
         this.enterContainerMode();
+
+        // Remove FAMOUS prefix command
+        windowCommands.shift();
 
         this._thread.postMessage(windowCommands);
         this._sendDrawCommands();

--- a/renderers/UIManager.js
+++ b/renderers/UIManager.js
@@ -51,20 +51,31 @@ var Commands = require('../core/Commands');
  * property and sending updates using `postMessage`.
  * @param {Compositor} compositor an instance of Compositor used to extract
  * enqueued draw commands from to be sent to the thread.
- * @param {RenderLoop} renderLoop an instance of Engine used for executing
- * the `ENGINE` commands on.
+ * @param {RenderLoop} [renderLoop] an instance of RenderLoop used for updating
+ * the UIManager when not running in container mode. Target for the ENGINE
+ * commands. Optional when running exclusively in container mode.
  */
 function UIManager (thread, compositor, renderLoop) {
+    var _this = this;
+
     this._thread = thread;
     this._compositor = compositor;
     this._renderLoop = renderLoop;
 
-    this._renderLoop.update(this);
+    if (renderLoop) {
+        this._renderLoop.update(this);
+    }
 
-    var _this = this;
     this._thread.onmessage = function (ev) {
         var message = ev.data ? ev.data : ev;
         if (message[0] === Commands.ENGINE) {
+            if (!_this._renderLoop) {
+                console.error(
+                    'Can not process ENGINE commands since no orender loop' +
+                    'is available.'
+                );
+                return;
+            }
             switch (message[1]) {
                 case Commands.START:
                     _this._engine.start();
@@ -86,6 +97,11 @@ function UIManager (thread, compositor, renderLoop) {
     this._thread.onerror = function (error) {
         console.error(error);
     };
+
+    this._containerMode = false;
+    window.addEventListener('message', function (message) {
+        _this._handleWindowMessage(message);
+    });
 }
 
 /**
@@ -149,9 +165,90 @@ UIManager.prototype.getRenderLoop = function getRenderLoop() {
  */
 UIManager.prototype.update = function update (time) {
     this._thread.postMessage([Commands.FRAME, time]);
+    this._sendDrawCommands();
+};
+
+
+/**
+ * Method used for sending the compositor's draw commands to the managed thread
+ * (Worker or Channel). Clears the compositor.
+ *
+ * @method  _sendDrawCommands
+ * @private
+ *
+ * @return {undefined}      undefined
+ */
+UIManager.prototype._sendDrawCommands = function _sendDrawCommands () {
     var threadMessages = this._compositor.drawCommands();
     this._thread.postMessage(threadMessages);
     this._compositor.clearCommands();
+};
+
+
+/**
+ * Container mode will automatically be entered after receving the initial
+ * window commands from the container manager.
+ *
+ * Entering container mode results into the currently active render loop to be
+ * stopped, assuming it is available.
+ *
+ * @method
+ * @return {undefined}          undefined
+ */
+UIManager.prototype.enterContainerMode = function enterContainerMode () {
+    if (!this._containerMode) {
+        this._containerMode = true;
+        if (this._renderLoop) this._renderLoop.stop();
+    }
+};
+
+
+/**
+ * Exits from container mode. Starts the render loop if possible, but won't
+ * prevent the UIManager from receiveing further messages.
+ *
+ * @method
+ * @return {undefined}          undefined
+ */
+UIManager.prototype.exitContainerMode = function exitContainerMode () {
+    if (!this._containerMode) {
+        this._containerMode = false;
+        if (this._renderLoop) this._renderLoop.start();
+    }
+};
+
+
+/**
+ * Listener function used for receiveing window messages.
+ *
+ * @method
+ * @private
+ *
+ * @param  {Object} message     Received window message.
+ * @return {undefined}          undefined
+ */
+UIManager.prototype._handleWindowMessage = function _handleWindowMessage (message) {
+    var windowCommands = message.data;
+    if (windowCommands && windowCommands.constructor === Array) {
+        this.enterContainerMode();
+
+        this._thread.postMessage(windowCommands);
+        this._sendDrawCommands();
+    }
+};
+
+
+/**
+ * Method used for determining whether the UIManger is currently running in
+ * container mode.
+ *
+ * @method
+ *
+ * @return {Boolean}    Boolean value indicating whether the UIManager is
+ * currently running in container mode.
+ */
+UIManager.prototype.isContainerMode = function isContainerMode () {
+    return this._containerMode;
 };
 
 module.exports = UIManager;

--- a/renderers/test/UIManager.js
+++ b/renderers/test/UIManager.js
@@ -165,4 +165,8 @@ test('UIManager', function(t) {
 
         t.equal(clearedCommands, true);
     });
+
+    t.test('Container Mode', function(t) {
+        t.end();
+    });
 });


### PR DESCRIPTION
## Proof of concept

```js
new UIManager(FamousEngine.getChannel(), new Compositor());

requestAnimationFrame(function loop(time) {
    window.postMessage(['FAMOUS', 'FRAME', time*2], '*');
    requestAnimationFrame(loop);
});
```