### PR TITLE
fix: Fix initial glitch (Context solution)

### DIFF
--- a/core/Scene.js
+++ b/core/Scene.js
@@ -71,7 +71,6 @@ function Scene (selector, updater) {
         .message(selector);        // the scene graph has a total size
 
     this.show(); // the context begins shown (it's already present in the dom)
-
 }
 
 // Scene inherits from node
@@ -122,7 +121,6 @@ Scene.prototype.onReceive = function onReceive (event, payload) {
     // and the context would receive its size the same way that any render size
     // component receives its size.
     if (event === 'CONTEXT_RESIZE') {
-
         if (payload.length < 2)
             throw new Error(
                     'CONTEXT_RESIZE\'s payload needs to be at least a pair' +
@@ -134,8 +132,8 @@ Scene.prototype.onReceive = function onReceive (event, payload) {
                              payload[1],
                              payload[2] ? payload[2] : 0);
 
+         this._updater.message('WITH').message(this._selector).message('READY');
     }
 };
 
 module.exports = Scene;
-

--- a/dom-renderers/DOMRenderer.js
+++ b/dom-renderers/DOMRenderer.js
@@ -84,8 +84,6 @@ function DOMRenderer (element, selector, compositor) {
 
     this.perspectiveTransform = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
     this._VPtransform = new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
-
-    this._size = [null, null];
 }
 
 
@@ -196,24 +194,6 @@ function _getPath(ev) {
     }
     return path;
 }
-
-
-/**
- * Determines the size of the context by querying the DOM for `offsetWidth` and
- * `offsetHeight`.
- *
- * @method
- *
- * @return {Array} Offset size.
- */
-DOMRenderer.prototype.getSize = function getSize() {
-    this._size[0] = this._root.element.offsetWidth;
-    this._size[1] = this._root.element.offsetHeight;
-    return this._size;
-};
-
-DOMRenderer.prototype._getSize = DOMRenderer.prototype.getSize;
-
 
 /**
  * Executes the retrieved draw commands. Draw commands only refer to the


### PR DESCRIPTION
Alternative to #185 using Context.

Change to the way we retrieve the Context Size: `getSize` method has been moved from `DOMRenderer` to `Context`.

@michaelobriena