### PR TITLE
fix: Fix exit codes for test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "tape": "tap-closer | smokestack -b firefox",
+    "tape": "tap-closer | smokestack -b firefox |tap-spec",
     "test-components": "browserify components/test/*.js | npm run tape",
     "test-core": "browserify core/test/*.js | npm run tape",
     "test-dom-renderables": "browserify dom-renderables/test/*.js | npm run tape",
@@ -38,6 +38,7 @@
     "eslint": "^0.21.2",
     "smokestack": "^3.2.2",
     "tap-closer": "^1.0.0",
+    "tap-spec": "^4.0.0",
     "tape": "^4.0.0",
     "uglify-js": "^2.4.17"
   },


### PR DESCRIPTION
The test scripts don't emit the correct exit codes. Adding tap-spec solves the issue. The issue where tap-spec was eating our errors seems to have been [fixed](https://github.com/scottcorgan/tap-spec/commit/24d2867d96d049c289e4c5ad8d6894963d472bba).

@michaelobriena If you decide to merge this, please do so before anything else. We then need to rerun the Travis builds for the remaining PRs to check if they actually pass.

:rage4: