### PR TITLE
Fix bug: guard against components[j] == null

### DIFF
--- a/core/Size.js
+++ b/core/Size.js
@@ -70,9 +70,11 @@ Size.prototype.fromSpecWithParent = function fromSpecWithParent (parentSize, nod
                 break;
             case Size.RENDER:
                 var candidate;
+                var component;
                 for (j = 0; j < len ; j++) {
-                    if (components[j] && components[j].getRenderSize) {
-                        candidate = components[j].getRenderSize()[i];
+                    component = components[j];
+                    if (component && component.getRenderSize) {
+                        candidate = component.getRenderSize()[i];
                         prev = target[i];
                         target[i] = target[i] < candidate || target[i] === 0 ? candidate : target[i];
                     }

--- a/core/Size.js
+++ b/core/Size.js
@@ -71,7 +71,7 @@ Size.prototype.fromSpecWithParent = function fromSpecWithParent (parentSize, nod
             case Size.RENDER:
                 var candidate;
                 for (j = 0; j < len ; j++) {
-                    if (components[j].getRenderSize) {
+                    if (components[j] && components[j].getRenderSize) {
                         candidate = components[j].getRenderSize()[i];
                         prev = target[i];
                         target[i] = target[i] < candidate || target[i] === 0 ? candidate : target[i];


### PR DESCRIPTION
`node.removeComponent()` updates internal component list by setting `this._components[index] = null;`.

This PR fixes the following error message by guarding against `components[j] == null`:

![screen shot 2015-05-31 at 6 14 45 pm](https://cloud.githubusercontent.com/assets/61540/7904216/1a3f97d2-07c1-11e5-83ab-e7921e639de7.png)