### PR TITLE
feat: Add ability to get the native Element of a DOMElement

### DIFF
--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -75,6 +75,8 @@ function DOMElement(node, options) {
     this._attributes = {};
     this._content = '';
 
+    this._el = null;
+
     this._tagName = options && options.tagName ? options.tagName : 'div';
     this._id = node ? node.addComponent(this) : null;
 
@@ -626,12 +628,32 @@ DOMElement.prototype.on = function on (event, listener) {
  * @return {undefined} undefined
  */
 DOMElement.prototype.onReceive = function onReceive (event, payload) {
-    if (event === 'resize') {
-        this._renderSize[0] = payload.val[0];
-        this._renderSize[1] = payload.val[1];
-        if (!this._requestingUpdate) this._requestUpdate();
+    switch (event) {
+        case 'resize':
+            this._renderSize[0] = payload.val[0];
+            this._renderSize[1] = payload.val[1];
+            if (!this._requestingUpdate) this._requestUpdate();
+            break;
+        case 'insertEl':
+            this._el = payload.el;
+            break;
     }
     this._callbacks.trigger(event, payload);
+};
+
+/**
+ * Provides access to the native Element associated with the DOMElement.
+ * The DOMElement returns `null` when the Element has not been created yet or
+ * when running in a Web Worker, in which case access to native Elements is
+ * technically not possinble.
+ *
+ * @method
+ *
+ * @return {Element|null} el    The native Element associated with the virtual
+ *                              DOMElement.
+ */
+DOMElement.prototype.getEl = function getEl () {
+    return this._el;
 };
 
 /**

--- a/dom-renderers/DOMRenderer.js
+++ b/dom-renderers/DOMRenderer.js
@@ -426,6 +426,10 @@ DOMRenderer.prototype.insertEl = function insertEl (tagName) {
             this._target.element.appendChild(this._children[i].element);
         }
     }
+
+    this._compositor.sendEvent(this._path, 'insertEl', {
+        el: this._target.element
+    }, true);
 };
 
 


### PR DESCRIPTION
* Add Compositor#stripNonCloneableOutCommands
* Add Compositor#message
* Add DOMElement#getEl

Non-cloneable objects are also being pushed onto the _outCommands
queue, but their index will be stored separately.
stripNonCloneableOutCommands is then being used in order to prepare the
command queue for postMessage.

@DnMllr I don't think there is a cleaner solution for this use case.