### PR TITLE
feat: Add utilities#assert

### DIFF
--- a/dom-renderers/DOMRenderer.js
+++ b/dom-renderers/DOMRenderer.js
@@ -28,6 +28,7 @@ var ElementCache = require('./ElementCache');
 var math = require('./Math');
 var vendorPrefix = require('../utilities/vendorPrefix');
 var eventMap = require('./events/EventMap');
+var assert = require('../utilities/assert');
 
 var TRANSFORM = null;
 
@@ -88,7 +89,6 @@ function DOMRenderer (element, selector, compositor) {
     this._size = [null, null];
 }
 
-
 /**
  * Attaches an EventListener to the element associated with the passed in path.
  * Prevents the default browser action on all subsequent events if
@@ -106,7 +106,7 @@ function DOMRenderer (element, selector, compositor) {
  */
 DOMRenderer.prototype.subscribe = function subscribe(type, preventDefault) {
     // TODO preventDefault should be a separate command
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
 
     this._target.preventDefault[type] = preventDefault;
     this._target.subscribe[type] = true;
@@ -166,7 +166,6 @@ DOMRenderer.prototype._triggerEvent = function _triggerEvent(ev) {
     }
 };
 
-
 /**
  * getSizeOf gets the dom size of a particular DOM element.  This is
  * needed for render sizing in the scene graph.
@@ -197,7 +196,6 @@ function _getPath(ev) {
     return path;
 }
 
-
 /**
  * Determines the size of the context by querying the DOM for `offsetWidth` and
  * `offsetHeight`.
@@ -213,7 +211,6 @@ DOMRenderer.prototype.getSize = function getSize() {
 };
 
 DOMRenderer.prototype._getSize = DOMRenderer.prototype.getSize;
-
 
 /**
  * Executes the retrieved draw commands. Draw commands only refer to the
@@ -256,55 +253,6 @@ DOMRenderer.prototype.draw = function draw(renderState) {
     }
 };
 
-
-/**
- * Internal helper function used for ensuring that a path is currently loaded.
- *
- * @method
- * @private
- *
- * @return {undefined} undefined
- */
-DOMRenderer.prototype._assertPathLoaded = function _asserPathLoaded() {
-    if (!this._path) throw new Error('path not loaded');
-};
-
-/**
- * Internal helper function used for ensuring that a parent is currently loaded.
- *
- * @method
- * @private
- *
- * @return {undefined} undefined
- */
-DOMRenderer.prototype._assertParentLoaded = function _assertParentLoaded() {
-    if (!this._parent) throw new Error('parent not loaded');
-};
-
-/**
- * Internal helper function used for ensuring that children are currently
- * loaded.
- *
- * @method
- * @private
- *
- * @return {undefined} undefined
- */
-DOMRenderer.prototype._assertChildrenLoaded = function _assertChildrenLoaded() {
-    if (!this._children) throw new Error('children not loaded');
-};
-
-/**
- * Internal helper function used for ensuring that a target is currently loaded.
- *
- * @method  _assertTargetLoaded
- *
- * @return {undefined} undefined
- */
-DOMRenderer.prototype._assertTargetLoaded = function _assertTargetLoaded() {
-    if (!this._target) throw new Error('No target loaded');
-};
-
 /**
  * Finds and sets the parent of the currently loaded element (path).
  *
@@ -314,7 +262,7 @@ DOMRenderer.prototype._assertTargetLoaded = function _assertTargetLoaded() {
  * @return {ElementCache} Parent element.
  */
 DOMRenderer.prototype.findParent = function findParent () {
-    this._assertPathLoaded();
+    assert(this._path, 'No path loaded');
 
     var path = this._path;
     var parent;
@@ -326,7 +274,6 @@ DOMRenderer.prototype.findParent = function findParent () {
     this._parent = parent;
     return parent;
 };
-
 
 /**
  * Finds all children of the currently loaded element.
@@ -340,7 +287,7 @@ DOMRenderer.prototype.findParent = function findParent () {
  */
 DOMRenderer.prototype.findChildren = function findChildren(array) {
     // TODO: Optimize me.
-    this._assertPathLoaded();
+    assert(this._path, 'No path loaded');
 
     var path = this._path + '/';
     var keys = Object.keys(this._elements);
@@ -371,7 +318,6 @@ DOMRenderer.prototype.findChildren = function findChildren(array) {
     return array;
 };
 
-
 /**
  * Used for determining the target loaded under the current path.
  *
@@ -383,7 +329,6 @@ DOMRenderer.prototype.findTarget = function findTarget() {
     this._target = this._elements[this._path];
     return this._target;
 };
-
 
 /**
  * Loads the passed in path.
@@ -398,7 +343,6 @@ DOMRenderer.prototype.loadPath = function loadPath (path) {
     this._path = path;
     return this._path;
 };
-
 
 /**
  * Inserts a DOMElement at the currently loaded path, assuming no target is
@@ -417,8 +361,8 @@ DOMRenderer.prototype.insertEl = function insertEl (tagName) {
         this.findParent();
         this.findChildren();
 
-        this._assertParentLoaded();
-        this._assertChildrenLoaded();
+        assert(this._parent, 'No parent loaded');
+        assert(this._children, 'No children loaded');
 
         if (this._target) this._parent.element.removeChild(this._target.element);
 
@@ -432,7 +376,6 @@ DOMRenderer.prototype.insertEl = function insertEl (tagName) {
     }
 };
 
-
 /**
  * Sets a property on the currently loaded target.
  *
@@ -444,10 +387,9 @@ DOMRenderer.prototype.insertEl = function insertEl (tagName) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setProperty = function setProperty (name, value) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this._target.element.style[name] = value;
 };
-
 
 /**
  * Sets the size of the currently loaded target.
@@ -462,7 +404,7 @@ DOMRenderer.prototype.setProperty = function setProperty (name, value) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setSize = function setSize (width, height) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
 
     this.setWidth(width);
     this.setHeight(height);
@@ -480,7 +422,7 @@ DOMRenderer.prototype.setSize = function setSize (width, height) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setWidth = function setWidth(width) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
 
     var contentWrapper = this._target.content;
 
@@ -511,7 +453,7 @@ DOMRenderer.prototype.setWidth = function setWidth(width) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setHeight = function setHeight(height) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
 
     var contentWrapper = this._target.content;
 
@@ -541,7 +483,7 @@ DOMRenderer.prototype.setHeight = function setHeight(height) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setAttribute = function setAttribute(name, value) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this._target.element.setAttribute(name, value);
 };
 
@@ -555,7 +497,7 @@ DOMRenderer.prototype.setAttribute = function setAttribute(name, value) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.setContent = function setContent(content) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this.findChildren();
 
     if (!this._target.content) {
@@ -574,7 +516,6 @@ DOMRenderer.prototype.setContent = function setContent(content) {
     );
 };
 
-
 /**
  * Sets the passed in transform matrix (world space). Inverts the parent's world
  * transform.
@@ -587,7 +528,7 @@ DOMRenderer.prototype.setContent = function setContent(content) {
  */
 DOMRenderer.prototype.setMatrix = function setMatrix(transform) {
     // TODO Don't multiply matrics in the first place.
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this.findParent();
     var worldTransform = this._target.worldTransform;
     var changed = false;
@@ -623,7 +564,6 @@ DOMRenderer.prototype.setMatrix = function setMatrix(transform) {
     this._target.element.style[TRANSFORM] = this._stringifyMatrix(this._target.finalTransform);
 };
 
-
 /**
  * Adds a class to the classList associated with the currently loaded target.
  *
@@ -634,10 +574,9 @@ DOMRenderer.prototype.setMatrix = function setMatrix(transform) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.addClass = function addClass(domClass) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this._target.element.classList.add(domClass);
 };
-
 
 /**
  * Removes a class from the classList associated with the currently loaded
@@ -650,10 +589,9 @@ DOMRenderer.prototype.addClass = function addClass(domClass) {
  * @return {undefined} undefined
  */
 DOMRenderer.prototype.removeClass = function removeClass(domClass) {
-    this._assertTargetLoaded();
+    assert(this._target, 'No target loaded');
     this._target.element.classList.remove(domClass);
 };
-
 
 /**
  * Stringifies the passed in matrix for setting the `transform` property.

--- a/utilities/assert.js
+++ b/utilities/assert.js
@@ -24,16 +24,8 @@
 
 'use strict';
 
-module.exports = {
-    assert: require('./assert'),
-    CallbackStore: require('./CallbackStore'),
-    clamp: require('./clamp'),
-    clone: require('./clone'),
-    Color: require('./Color'),
-    KeyCodes: require('./KeyCodes'),
-    keyValueToArrays: require('./keyValueToArrays'),
-    loadURL: require('./loadURL'),
-    ObjectManager: require('./ObjectManager'),
-    strip: require('./strip'),
-    vendorPrefix: require('./vendorPrefix')
-};
+function assert(value, errorMsg) {
+    if (!value) throw new Error('Failed assertion! ' + errorMsg);
+}
+
+module.exports = assert;


### PR DESCRIPTION
DOMRenderer previously had methods for asserting state.

Putting those methods on the prototype makes it impossible for the
minifier to do any kind of dead-code elimination.

This commit adds an assert utility function used in order to check
if a certain condition is met.

Checking for NODE_ENV and not including the passed in error message
in the thrown error should be trivial and only needs to be done once
in the more generic assert function.