### PR TITLE
clean: Remove broken window check

### DIFF
--- a/webgl-renderers/TextureManager.js
+++ b/webgl-renderers/TextureManager.js
@@ -121,7 +121,7 @@ TextureManager.prototype.register = function register(input, slot) {
 
         // Handle video
 
-        else if (window && source instanceof window.HTMLVideoElement) {
+        else if (source instanceof HTMLVideoElement) {
             source.addEventListener('loadeddata', function() {
                 _this.bindTexture(textureId);
                 texture.setImage(source);


### PR DESCRIPTION
The TextureManager is only being used by the WebGLRenderer, which always runs
in the UI thread. Therefore there is no need to check for the environment it
runs in. Besides that, the check would throw an error anyways when being
evaluated in a worker, since window wouldn't be defined. This check never
worked. If we really want to check if we're in a worker, we need to
check if "typeof window !== 'undefined".

@redwoodfavorite 