### PR TITLE
fix: fixing blending option and setDrawOptions for unmounted nodes

### DIFF
--- a/webgl-renderables/Mesh.js
+++ b/webgl-renderables/Mesh.js
@@ -46,7 +46,7 @@ function Mesh (node, options) {
     this._requestingUpdate = false;
     this._inDraw = false;
     this.value = {
-        drawOptions: {},
+        drawOptions: null,
         color: null,
         expressions: {},
         geometry: null,
@@ -72,6 +72,8 @@ function Mesh (node, options) {
 Mesh.prototype.setDrawOptions = function setDrawOptions (options) {
     this._changeQueue.push('GL_SET_DRAW_OPTIONS');
     this._changeQueue.push(options);
+
+    this.value.drawOptions = options;
     return this;
 };
 

--- a/webgl-renderers/WebGLRenderer.js
+++ b/webgl-renderers/WebGLRenderer.js
@@ -810,13 +810,14 @@ WebGLRenderer.prototype.handleOptions = function handleOptions(options, mesh) {
     var gl = this.gl;
     if (!options) return;
 
+    if (options.blending) gl.enable(gl.BLEND);
+
     if (options.side === 'double') {
         this.gl.cullFace(this.gl.FRONT);
         this.drawBuffers(this.bufferRegistry.registry[mesh.geometry], mesh.drawType, mesh.geometry);
         this.gl.cullFace(this.gl.BACK);
     }
 
-    if (options.blending) gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
     if (options.side === 'back') gl.cullFace(gl.FRONT);
 };
 
@@ -832,7 +833,7 @@ WebGLRenderer.prototype.handleOptions = function handleOptions(options, mesh) {
 WebGLRenderer.prototype.resetOptions = function resetOptions(options) {
     var gl = this.gl;
     if (!options) return;
-    if (options.blending) gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+    if (options.blending) gl.disable(gl.BLEND);
     if (options.side === 'back') gl.cullFace(gl.BACK);
 };
 


### PR DESCRIPTION
Previously, setDrawOptions was not setting the value.drawOptions, which caused unmounted nodes to always receive an empty object as drawOptions, overriding any set value...