### PR TITLE
fix: Show nodes by default

### DIFF
--- a/core/Node.js
+++ b/core/Node.js
@@ -74,7 +74,7 @@ function Node () {
     this._requestingUpdate = false;
     this._inUpdate = false;
     this._mounted = false;
-    this._shown = false;
+    this._shown = true;
     this._updater = null;
     this._opacity = 1;
     this._UIEvents = [];
@@ -121,7 +121,7 @@ Node.prototype._init = function _init () {
  * Protected method. Sets the parent of this node such that it can be looked up.
  *
  * @method
- * 
+ *
  * @param {Node} parent The node to set as the parent of this
  *
  * @return {undefined} undefined;
@@ -231,7 +231,7 @@ Node.prototype.getValue = function getValue () {
     var numberOfChildren = this._children.length;
     var numberOfComponents = this._components.length;
     var i = 0;
- 
+
     var value = {
         location: this.getId(),
         spec: {
@@ -263,7 +263,7 @@ Node.prototype.getValue = function getValue () {
         components: [],
         children: []
     };
-    
+
     if (value.location) {
         var transform = TransformSystem.get(this.getId());
         var size = SizeSystem.get(this.getId());
@@ -401,6 +401,18 @@ Node.prototype.requestUpdateOnNextTick = function requestUpdateOnNextTick (reque
  */
 Node.prototype.isMounted = function isMounted () {
     return this._mounted;
+};
+
+/**
+ * Checks if the node is being rendered. A node is being rendererd when it is
+ * mounted to a parent node **and** shown.
+ *
+ * @method isRendered
+ *
+ * @return {Boolean}    Boolean indicating whether the node is rendered or not.
+ */
+Node.prototype.isRendered = function isRendered () {
+    return this._mounted && this._shown;
 };
 
 /**
@@ -749,7 +761,7 @@ Node.prototype.removeComponent = function removeComponent (component) {
 };
 
 /**
- * Removes a node's subscription to a particular UIEvent. All components 
+ * Removes a node's subscription to a particular UIEvent. All components
  * on the node will have the opportunity to remove all listeners depending
  * on this event.
  *

--- a/core/test/Channel.js
+++ b/core/test/Channel.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -48,13 +48,13 @@ test('Channel', function(t) {
             var expectedMessage = [1, 2, 3];
             channel.sendMessage(expectedMessage);
         });
-        
+
         t.test('onMessage method', function(t) {
             t.plan(2);
             var channel = new Channel();
             channel.onmessage = function() {
                 t.fail(
-                    'Channel#postMessage should send message TO the "Worker"'
+                    'Channel#postMessage should send message to the "Worker"'
                 );
             };
             var expectedMessage = [1, 2, 3];

--- a/core/test/Node.js
+++ b/core/test/Node.js
@@ -197,11 +197,15 @@ test('Node', function(t) {
     t.test('isShown method', function(t) {
         var child = new Node();
         t.equal(typeof child.isShown, 'function', 'child.isShown should be a function');
-        t.equal(child.isShown(), false, 'nodes should not be shown when being initialized');
+        t.equal(child.isShown(), true, 'nodes should be shown by default');
+
+        child.hide();
+
+        t.equal(child.isShown(), false, 'node.isShown should return false when node has been hidden using Node#hide');
 
         child.show();
 
-        t.equal(child.isShown(), true, 'node.isShown should indicate shown state after node has been mounted');
+        t.equal(child.isShown(), true, 'node.isShown should return true when node has been shown using Node#shown');
 
         t.end();
     });

--- a/core/test/expected/DefaultNodeSpec.json
+++ b/core/test/expected/DefaultNodeSpec.json
@@ -2,7 +2,7 @@
     "location": null,
     "showState": {
         "mounted": false,
-        "shown": false,
+        "shown": true,
         "opacity": 1
     },
     "offsets": {


### PR DESCRIPTION
Currently nodes are hidden by default. We can either call Node#show in
Node#mount or simply change the spec to indicate the shown node by default.
Calling Node#show in Node#mount means mounting nodes shows them by
default, which is also unintuitive when hiding a detached node.

Fixes #277