### PR TITLE
fix: made method names consistent in size

### DIFF
--- a/core/Size.js
+++ b/core/Size.js
@@ -208,7 +208,7 @@ Size.prototype.setAbsolute = function setAbsolute (x, y, z) {
  *
  * @return {array} array of absolute size
  */
-Size.prototype.getAbsoluteSize = function getAbsoluteSize () {
+Size.prototype.getAbsolute = function getAbsolute () {
     return this.absoluteSize;
 };
 
@@ -235,7 +235,7 @@ Size.prototype.setProportional = function setProportional (x, y, z) {
  *
  * @return {array} array of proportional size
  */
-Size.prototype.getProportionalSize = function getProportionalSize () {
+Size.prototype.getProportional = function getProportional () {
     return this.proportionalSize;
 };
 

--- a/core/SizeSystem.js
+++ b/core/SizeSystem.js
@@ -161,7 +161,7 @@ function sizeModeChanged (node, components, size) {
  * @return {undefined} undefined
  */
 function absoluteSizeChanged (node, components, size) {
-    var absoluteSize = size.getAbsoluteSize();
+    var absoluteSize = size.getAbsolute();
     var x = absoluteSize[0];
     var y = absoluteSize[1];
     var z = absoluteSize[2];
@@ -185,7 +185,7 @@ function absoluteSizeChanged (node, components, size) {
  * @return {undefined} undefined
  */
 function proportionalSizeChanged (node, components, size) {
-    var proportionalSize = size.getProportionalSize();
+    var proportionalSize = size.getProportional();
     var x = proportionalSize[0];
     var y = proportionalSize[1];
     var z = proportionalSize[2];


### PR DESCRIPTION
fixes issue #298

by making the methods on the Size class consistent.