### PR TITLE
Propoagate Opacity [#93734958]

### DIFF
--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -32,6 +32,7 @@ var UIManager = require('../renderers/UIManager');
 var Compositor = require('../renderers/Compositor');
 var RequestAnimationFrameLoop = require('../render-loops/RequestAnimationFrameLoop');
 var TransformSystem = require('./TransformSystem');
+var OpacitySystem = require('./OpacitySystem');
 var SizeSystem = require('./SizeSystem');
 var Commands = require('./Commands');
 
@@ -158,6 +159,7 @@ FamousEngine.prototype._update = function _update () {
 
     SizeSystem.update();
     TransformSystem.update();
+    OpacitySystem.update();
 
     while (nextQueue.length) queue.unshift(nextQueue.pop());
 

--- a/core/Node.js
+++ b/core/Node.js
@@ -247,7 +247,7 @@ Node.prototype.getValue = function getValue () {
             showState: {
                 mounted: this.isMounted(),
                 shown: this.isShown(),
-                opacity: this.getOpacity() || null
+                opacity: 1
             },
             offsets: {
                 mountPoint: [0, 0, 0],
@@ -275,6 +275,9 @@ Node.prototype.getValue = function getValue () {
     if (value.location) {
         var transform = TransformSystem.get(this.getId());
         var size = SizeSystem.get(this.getId());
+        var opacity = SizeSystem.get(this.getId());
+
+        value.spec.showState.opacity = opacity.getOpacity();
 
         for (i = 0 ; i < 3 ; i++) {
             value.spec.offsets.mountPoint[i] = transform.offsets.mountPoint[i];
@@ -322,7 +325,8 @@ Node.prototype.getComputedValue = function getComputedValue () {
         location: this.getId(),
         computedValues: {
             transform: this.isMounted() ? TransformSystem.get(this.getLocation()).getLocalTransform() : null,
-            size: this.isMounted() ? SizeSystem.get(this.getLocation()).get() : null
+            size: this.isMounted() ? SizeSystem.get(this.getLocation()).get() : null,
+            opacity: this.isMounted() ? OpacitySystem.get(this.getLocation()).get() : null
         },
         children: []
     };
@@ -479,7 +483,7 @@ Node.prototype.getOpacity = function getOpacity () {
     if (this.constructor.INIT_DEFAULT_COMPONENTS)
         return this.getComponent(this._opacityID).getOpacity();
     else if (this.isMounted())
-        return TransformSystem.get(this.getLocation()).getOpacity();
+        return OpacitySystem.get(this.getLocation()).getOpacity();
     else throw new Error('This node does not have access to an opacity component');
 };
 
@@ -1081,7 +1085,7 @@ Node.prototype.setOpacity = function setOpacity (val) {
     if (this.constructor.INIT_DEFAULT_COMPONENTS)
         this.getComponent(this._opacityID).setOpacity(val);
     else if (this.isMounted())
-        SizeSystem.get(this.getLocation()).setOpacity(val);
+        OpacitySystem.get(this.getLocation()).setOpacity(val);
     else throw new Error('This node does not have access to an opacity component');
     return this;
 };
@@ -1266,10 +1270,12 @@ Node.prototype.mount = function mount (path) {
 
     if (!this.constructor.NO_DEFAULT_COMPONENTS){
         TransformSystem.registerTransformAtPath(path, this.getComponent(this._transformID));
+        OpacitySystem.registerOpacityAtPath(path, this.getComponent(this._opacityID));
         SizeSystem.registerSizeAtPath(path, this.getComponent(this._sizeID));
     }
     else {
         TransformSystem.registerTransformAtPath(path);
+        OpacitySystem.registerOpacityAtPath(path);
         SizeSystem.registerSizeAtPath(path);
     }
     Dispatch.mount(path, this);
@@ -1295,6 +1301,7 @@ Node.prototype.dismount = function dismount () {
 
     TransformSystem.deregisterTransformAtPath(path);
     SizeSystem.deregisterSizeAtPath(path);
+    OpacitySystem.deregisterOpacityAtPath(path);
     Dispatch.dismount(path);
 
     if (!this._requestingUpdate) this._requestUpdate();

--- a/core/Node.js
+++ b/core/Node.js
@@ -480,7 +480,7 @@ Node.prototype.isShown = function isShown () {
  * @return {Number}         Relative opacity of the node.
  */
 Node.prototype.getOpacity = function getOpacity () {
-    if (this.constructor.INIT_DEFAULT_COMPONENTS)
+    if (!this.constructor.NO_DEFAULT_COMPONENTS)
         return this.getComponent(this._opacityID).getOpacity();
     else if (this.isMounted())
         return OpacitySystem.get(this.getLocation()).getOpacity();
@@ -1082,7 +1082,7 @@ Node.prototype.setScale = function setScale (x, y, z) {
  * @return {Node} this
  */
 Node.prototype.setOpacity = function setOpacity (val) {
-    if (this.constructor.INIT_DEFAULT_COMPONENTS)
+    if (!this.constructor.NO_DEFAULT_COMPONENTS)
         this.getComponent(this._opacityID).setOpacity(val);
     else if (this.isMounted())
         OpacitySystem.get(this.getLocation()).setOpacity(val);

--- a/core/Node.js
+++ b/core/Node.js
@@ -275,7 +275,7 @@ Node.prototype.getValue = function getValue () {
     if (value.location) {
         var transform = TransformSystem.get(this.getId());
         var size = SizeSystem.get(this.getId());
-        var opacity = SizeSystem.get(this.getId());
+        var opacity = OpacitySystem.get(this.getId());
 
         value.spec.showState.opacity = opacity.getOpacity();
 

--- a/core/Opacity.js
+++ b/core/Opacity.js
@@ -30,6 +30,7 @@ function Opacity (parent) {
     this.opacity = 1;
     this.parent = parent ? parent : null;
     this.breakPoint = false;
+    this.calculatingWorldOpacity = false;
 }
 
 Opacity.WORLD_CHANGED = 1;
@@ -50,6 +51,18 @@ Opacity.prototype.getParent = function getParent () {
 
 Opacity.prototype.setBreakPoint = function setBreakPoint () {
     this.breakPoint = true;
+    this.calculatingWorldOpacity = true;
+};
+
+/**
+ * Set this node to calculate the world opacity.
+ *
+ * @method
+ *
+ * @return {undefined} undefined
+ */
+Opacity.prototype.setCalculateWorldOpacity = function setCalculateWorldOpacity () {
+    this.calculatingWorldOpacity = true;
 };
 
 Opacity.prototype.isBreakPoint = function isBreakPoint () {
@@ -61,7 +74,7 @@ Opacity.prototype.getLocalOpacity = function getLocalOpacity () {
 };
 
 Opacity.prototype.getWorldOpacity = function getWorldOpacity () {
-    if (!this.isBreakPoint())
+    if (!this.isBreakPoint() && !this.calculatingWorldOpacity)
         throw new Error('This opacity is not calculating world transforms');
     return this.global;
 };
@@ -106,7 +119,7 @@ Opacity.prototype.fromNode = function fromNode () {
 
     this.local = this.opacity;
 
-    if (this.isBreakPoint() && this.calculateWorldOpacity())
+    if (this.calculatingWorldOpacity && this.calculateWorldOpacity())
         changed |= Opacity.WORLD_CHANGED;
 
     return changed;
@@ -119,7 +132,7 @@ Opacity.prototype.fromNodeWithParent = function fromNodeWithParent () {
 
     this.local = this.parent.getLocalOpacity() * this.opacity;
 
-    if (this.isBreakPoint() && this.calculateWorldOpacity())
+    if (this.calculatingWorldOpacity && this.calculateWorldOpacity())
         changed |= Opacity.WORLD_CHANGED;
 
     if (previousLocal !== this.local)

--- a/core/Opacity.js
+++ b/core/Opacity.js
@@ -1,0 +1,128 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Famous Industries Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+function Opacity (parent) {
+    this.local = 1;
+    this.global = 1;
+    this.opacity = 1;
+    this.parent = parent ? parent : null;
+    this.breakPoint = false;
+}
+
+Opacity.WORLD_CHANGED = 1;
+Opacity.LOCAL_CHANGED = 2;
+
+Opacity.prototype.reset = function reset () {
+    this.parent = null;
+    this.breakPoint = false;
+};
+
+Opacity.prototype.setParent = function setParent (parent) {
+    this.parent = parent;
+};
+
+Opacity.prototype.getParent = function getParent () {
+    return this.parent;
+};
+
+Opacity.prototype.setBreakPoint = function setBreakPoint () {
+    this.breakPoint = true;
+};
+
+Opacity.prototype.isBreakPoint = function isBreakPoint () {
+    return this.breakPoint;
+};
+
+Opacity.prototype.getLocalOpacity = function getLocalOpacity () {
+    return this.local;
+};
+
+Opacity.prototype.getWorldOpacity = function getWorldOpacity () {
+    if (!this.isBreakPoint())
+        throw new Error('This opacity is not calculating world transforms');
+    return this.global;
+};
+
+Opacity.prototype.calculate = function calculate (node) {
+    if (!this.parent || this.parent.isBreakPoint())
+        return this.fromNode(node);
+    else return this.fromNodeWithParent(node);
+};
+
+Opacity.prototype.getOpacity = function getOpacity () {
+    return this.opacity;
+};
+
+Opacity.prototype.setOpacity = function setOpacity (opacity) {
+    this.opacity = opacity;
+};
+
+Opacity.prototype.calculateWorldOpacity = function calculateWorldOpacity () {
+    var nearestBreakPoint = this.parent;
+
+    while (nearestBreakPoint && !nearestBreakPoint.isBreakPoint())
+        nearestBreakPoint = nearestBreakPoint.parent;
+
+    if (nearestBreakPoint) {
+        this.global = nearestBreakPoint.getWorldOpacity() * this.local;
+    }
+    else {
+        this.global = this.local;
+        return false;
+    }
+};
+
+Opacity.prototype.fromNode = function fromNode () {
+    var changed = 0;
+
+    if (this.isBreakPoint() && this.calculateWorldOpacity())
+        changed |= Opacity.WORLD_CHANGED;
+
+    if (this.opacity !== this.local)
+        changed |= Opacity.LOCAL_CHANGED;
+
+    this.local = this.opacity;
+
+    return changed;
+};
+
+Opacity.prototype.fromNodeWithParent = function fromNodeWithParent () {
+    var oldLocalOpacity = this.getLocalOpacity();
+
+    var changed = 0;
+
+    this.localOpacity = this.parent.getLocalOpacity() * oldLocalOpacity;
+
+    if (this.isBreakPoint() && this.calculateWorldOpacity())
+        changed |= Opacity.WORLD_CHANGED;
+
+    if (oldLocalOpacity !== this.localOpacity)
+        changed |= Opacity.LOCAL_CHANGED;
+
+    return changed;
+};
+
+module.exports = Opacity;

--- a/core/Opacity.js
+++ b/core/Opacity.js
@@ -83,6 +83,8 @@ Opacity.prototype.setOpacity = function setOpacity (opacity) {
 Opacity.prototype.calculateWorldOpacity = function calculateWorldOpacity () {
     var nearestBreakPoint = this.parent;
 
+    var previousGlobal = this.global;
+
     while (nearestBreakPoint && !nearestBreakPoint.isBreakPoint())
         nearestBreakPoint = nearestBreakPoint.parent;
 
@@ -91,35 +93,36 @@ Opacity.prototype.calculateWorldOpacity = function calculateWorldOpacity () {
     }
     else {
         this.global = this.local;
-        return false;
     }
+
+    return previousGlobal !== this.global;
 };
 
 Opacity.prototype.fromNode = function fromNode () {
     var changed = 0;
-
-    if (this.isBreakPoint() && this.calculateWorldOpacity())
-        changed |= Opacity.WORLD_CHANGED;
 
     if (this.opacity !== this.local)
         changed |= Opacity.LOCAL_CHANGED;
 
     this.local = this.opacity;
 
+    if (this.isBreakPoint() && this.calculateWorldOpacity())
+        changed |= Opacity.WORLD_CHANGED;
+
     return changed;
 };
 
 Opacity.prototype.fromNodeWithParent = function fromNodeWithParent () {
-    var oldLocalOpacity = this.getLocalOpacity();
-
     var changed = 0;
 
-    this.localOpacity = this.parent.getLocalOpacity() * oldLocalOpacity;
+    var previousLocal = this.local;
+
+    this.local = this.parent.getLocalOpacity() * this.opacity;
 
     if (this.isBreakPoint() && this.calculateWorldOpacity())
         changed |= Opacity.WORLD_CHANGED;
 
-    if (oldLocalOpacity !== this.localOpacity)
+    if (previousLocal !== this.local)
         changed |= Opacity.LOCAL_CHANGED;
 
     return changed;

--- a/core/OpacitySystem.js
+++ b/core/OpacitySystem.js
@@ -44,9 +44,10 @@ function OpacitySystem () {
  * when the OpacitySystem updates.
  *
  * @method registerOpacityAtPath
- * @return {void}
  *
- * @param {String} path for the opacity to be registered to.
+ * @param {String} path path for the opacity to be registered to.
+ * @param {Opacity} [opacity] opacity to register.
+ * @return {undefined} undefined
  */
 OpacitySystem.prototype.registerOpacityAtPath = function registerOpacityAtPath (path, opacity) {
     if (!PathUtils.depth(path)) return this.pathStore.insert(path, opacity ? opacity : new Opacity());
@@ -63,7 +64,7 @@ OpacitySystem.prototype.registerOpacityAtPath = function registerOpacityAtPath (
 };
 
 /**
- * deregisters a opacity registered at the given path.
+ * Deregisters a opacity registered at the given path.
  *
  * @method deregisterOpacityAtPath
  * @return {void}
@@ -114,6 +115,7 @@ OpacitySystem.prototype.get = function get (path) {
  * in the scene graph
  *
  * @method update
+ * @return {undefined} undefined
  */
 OpacitySystem.prototype.update = function update () {
     var opacities = this.pathStore.getItems();

--- a/core/OpacitySystem.js
+++ b/core/OpacitySystem.js
@@ -74,8 +74,8 @@ OpacitySystem.prototype.deregisterOpacityAtPath = function deregisterOpacityAtPa
 /**
  * Method which will make the opacity currently stored at the given path a breakpoint.
  * A opacity being a breakpoint means that both a local and world opacity will be calculated
- * for that point. The local opacity being the concatinated opacity of all ancestor opacites up
- * until the nearest breakpoint, and the world being the concatinated opacity of all ancestor opacites.
+ * for that point. The local opacity being the concatinated opacity of all ancestor opacities up
+ * until the nearest breakpoint, and the world being the concatinated opacity of all ancestor opacities.
  * This method throws if no opacity is at the provided path.
  *
  * @method
@@ -106,25 +106,25 @@ OpacitySystem.prototype.get = function get (path) {
 
 /**
  * onUpdate is called when the opacity system requires an update.
- * It traverses the opacity array and evaluates the necessary opacites
+ * It traverses the opacity array and evaluates the necessary opacities
  * in the scene graph with the information from the corresponding node
  * in the scene graph
  *
  * @method onUpdate
  */
 OpacitySystem.prototype.onUpdate = function onUpdate () {
-    var opacites = this.pathStore.getItems();
+    var opacities = this.pathStore.getItems();
     var paths = this.pathStore.getPaths();
     var opacity;
     var changed;
     var node;
     var components;
 
-    for (var i = 0, len = opacites.length ; i < len ; i++) {
+    for (var i = 0, len = opacities.length ; i < len ; i++) {
         node = Dispatch.getNode(paths[i]);
         if (!node) continue;
         components = node.getComponents();
-        opacity = opacites[i];
+        opacity = opacities[i];
         if ((changed = opacity.from(node))) {
             opacityChanged(node, components, opacity);
             if (changed & Opacity.LOCAL_CHANGED) localOpacityChanged(node, components, opacity.getLocalOpacity());

--- a/core/OpacitySystem.js
+++ b/core/OpacitySystem.js
@@ -1,0 +1,196 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Famous Industries Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+var PathUtils = require('./Path');
+var Opacity = require('./Opacity');
+var Dispatch = require('./Dispatch');
+var PathStore = require('./PathStore');
+
+/**
+ * The opacity class is responsible for calculating the opacity of a particular
+ * node from the data on the node and its parent
+ *
+ * @constructor {OpacitySystem}
+ */
+function OpacitySystem () {
+    this.pathStore = new PathStore();
+}
+
+/**
+ * registers a new Opacity for the given path. This opacity will be updated
+ * when the OpacitySystem updates.
+ *
+ * @method registerOpacityAtPath
+ * @return {void}
+ *
+ * @param {String} path for the opacity to be registered to.
+ */
+OpacitySystem.prototype.registerOpacityAtPath = function registerOpacityAtPath (path) {
+    if (!PathUtils.depth(path)) return this.pathStore.insert(path, new Opacity());
+
+    var parent = this.pathStore.get(PathUtils.parent(path));
+
+    if (!parent) throw new Error(
+            'No parent opacity registered at expected path: ' + PathUtils.parent(path)
+    );
+    this.pathStore.insert(path, new Opacity(parent));
+};
+
+/**
+ * deregisters a opacity registered at the given path.
+ *
+ * @method deregisterOpacityAtPath
+ * @return {void}
+ *
+ * @param {String} path at which to register the opacity
+ */
+OpacitySystem.prototype.deregisterOpacityAtPath = function deregisterOpacityAtPath (path) {
+    this.pathStore.remove(path);
+};
+
+/**
+ * Method which will make the opacity currently stored at the given path a breakpoint.
+ * A opacity being a breakpoint means that both a local and world opacity will be calculated
+ * for that point. The local opacity being the concatinated opacity of all ancestor opacites up
+ * until the nearest breakpoint, and the world being the concatinated opacity of all ancestor opacites.
+ * This method throws if no opacity is at the provided path.
+ *
+ * @method
+ *
+ * @param {String} path The path at which to turn the opacity into a breakpoint
+ *
+ * @return {undefined} undefined
+ */
+OpacitySystem.prototype.makeBreakPointAt = function makeBreakPointAt (path) {
+    var opacity = this.pathStore.get(path);
+    if (!opacity) throw new Error('No opacity Registered at path: ' + path);
+    opacity.setBreakPoint();
+};
+
+/**
+ * Returns the instance of the opacity class associated with the given path,
+ * or undefined if no opacity is associated.
+ *
+ * @method
+ *
+ * @param {String} path The path to lookup
+ *
+ * @return {Opacity | undefined} the opacity at that path is available, else undefined.
+ */
+OpacitySystem.prototype.get = function get (path) {
+    return this.pathStore.get(path);
+};
+
+/**
+ * onUpdate is called when the opacity system requires an update.
+ * It traverses the opacity array and evaluates the necessary opacites
+ * in the scene graph with the information from the corresponding node
+ * in the scene graph
+ *
+ * @method onUpdate
+ */
+OpacitySystem.prototype.onUpdate = function onUpdate () {
+    var opacites = this.pathStore.getItems();
+    var paths = this.pathStore.getPaths();
+    var opacity;
+    var changed;
+    var node;
+    var components;
+
+    for (var i = 0, len = opacites.length ; i < len ; i++) {
+        node = Dispatch.getNode(paths[i]);
+        if (!node) continue;
+        components = node.getComponents();
+        opacity = opacites[i];
+        if ((changed = opacity.from(node))) {
+            opacityChanged(node, components, opacity);
+            if (changed & Opacity.LOCAL_CHANGED) localOpacityChanged(node, components, opacity.getLocalOpacity());
+            if (changed & Opacity.WORLD_CHANGED) worldOpacityChanged(node, components, opacity.getWorldOpacity());
+        }
+    }
+};
+
+/**
+ * Private method to call when either the Local or World Opacity changes.
+ * Triggers 'onOpacityChange' methods on the node and all of the node's components
+ *
+ * @method
+ * @private
+ *
+ * @param {Node} node the node on which to trigger a change event if necessary
+ * @param {Array} components the components on which to trigger a change event if necessary
+ * @param {Opacity} opacity the opacity class that changed
+ *
+ * @return {undefined} undefined
+ */
+function opacityChanged (node, components, opacity) {
+    if (node.onOpacityChange) node.onOpacityChange(opacity);
+    for (var i = 0, len = components.length ; i < len ; i++)
+        if (components[i] && components[i].onOpacityChange)
+            components[i].onOpacityChange(opacity);
+}
+
+/**
+ * Private method to call when the local opacity changes. Triggers 'onLocalOpacityChange' methods
+ * on the node and all of the node's components
+ *
+ * @method
+ * @private
+ *
+ * @param {Node} node the node on which to trigger a change event if necessary
+ * @param {Array} components the components on which to trigger a change event if necessary
+ * @param {Array} opacity the local opacity
+ *
+ * @return {undefined} undefined
+ */
+function localOpacityChanged (node, components, opacity) {
+    if (node.onLocalOpacityChange) node.onLocalOpacityChange(opacity);
+    for (var i = 0, len = components.length ; i < len ; i++)
+        if (components[i] && components[i].onLocalOpacityChange)
+            components[i].onLocalOpacityChange(opacity);
+}
+
+/**
+ * Private method to call when the world opacity changes. Triggers 'onWorldOpacityChange' methods
+ * on the node and all of the node's components
+ *
+ * @method
+ * @private
+ *
+ * @param {Node} node the node on which to trigger a change event if necessary
+ * @param {Array} components the components on which to trigger a change event if necessary
+ * @param {Array} opacity the world opacity
+ *
+ * @return {undefined} undefined
+ */
+function worldOpacityChanged (node, components, opacity) {
+    if (node.onWorldOpacityChange) node.onWorldOpacityChange(opacity);
+    for (var i = 0, len = components.length ; i < len ; i++)
+        if (components[i] && components[i].onWorldOpacityChange)
+            components[i].onWorldOpacityChange(opacity);
+}
+
+module.exports = new OpacitySystem();

--- a/core/OpacitySystem.js
+++ b/core/OpacitySystem.js
@@ -95,6 +95,21 @@ OpacitySystem.prototype.makeBreakPointAt = function makeBreakPointAt (path) {
 };
 
 /**
+ * Method that will make the opacity at this location calculate a world opacity.
+ *
+ * @method
+ *
+ * @param {String} path The path at which to make the opacity calculate a world matrix
+ *
+ * @return {undefined} undefined
+ */
+OpacitySystem.prototype.makeCalculateWorldOpacityAt = function makeCalculateWorldOpacityAt (path) {
+        var opacity = this.pathStore.get(path);
+        if (!opacity) throw new Error('No opacity opacity at path: ' + path);
+        opacity.setCalculateWorldOpacity();
+};
+
+/**
  * Returns the instance of the opacity class associated with the given path,
  * or undefined if no opacity is associated.
  *

--- a/core/Scene.js
+++ b/core/Scene.js
@@ -30,6 +30,7 @@ var Node = require('./Node');
 var Dispatch = require('./Dispatch');
 var Commands = require('./Commands');
 var TransformSystem = require('./TransformSystem');
+var OpacitySystem = require('./OpacitySystem');
 var SizeSystem = require('./SizeSystem');
 
 /**
@@ -147,6 +148,7 @@ Scene.prototype.mount = function mount (path) {
     this._mounted = true;
     this._parent = this;
     TransformSystem.registerTransformAtPath(path);
+    OpacitySystem.registerOpacityAtPath(path);
     SizeSystem.registerSizeAtPath(path);
 };
 

--- a/core/test/opacity/Opacity.api.js
+++ b/core/test/opacity/Opacity.api.js
@@ -1,0 +1,15 @@
+module.exports = [
+    'reset',
+    'setParent',
+    'getParent',
+    'setBreakPoint',
+    'isBreakPoint',
+    'getLocalOpacity',
+    'getWorldOpacity',
+    'calculate',
+    'getOpacity',
+    'setOpacity',
+    'calculateWorldOpacity',
+    'fromNode',
+    'fromNodeWithParent'
+];

--- a/core/test/opacity/Opacity.api.js
+++ b/core/test/opacity/Opacity.api.js
@@ -1,3 +1,29 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Famous Industries Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
 module.exports = [
     'reset',
     'setParent',

--- a/core/test/opacity/Opacity.spec.js
+++ b/core/test/opacity/Opacity.spec.js
@@ -1,0 +1,304 @@
+'use strict';
+
+var test = require('tape');
+var api = require('./Opacity.api');
+var Opacity = require('../../Opacity');
+var OpacityStub = require('./Opacity.stub');
+var NodeStub = require('../node/Node.stub');
+var sinon = require('sinon');
+
+function createTestNode () {
+    var node = new NodeStub();
+    // node.getSize.returns([100, 100, 100]);
+    // node.getParent.returns({ getSize: sinon.stub().returns([200, 200, 200]) });
+    return node;
+}
+
+test('Opacity class', function (t) {
+
+    t.test('Opacity constructor' , function (t) {
+
+        t.ok(Opacity, 'There should be a transform module');
+        t.equal(Opacity.constructor, Function, 'Opacity should be a function');
+
+        t.doesNotThrow(function () {
+            return new Opacity();
+        }, 'Opacity should be callable with new');
+
+        t.doesNotThrow(function () {
+            return new Opacity(new OpacityStub());
+        }, 'Opacity should be callable with new and another transform as an argument');
+
+        t.equal((new Opacity()).constructor, Opacity, 'Opacity should be a constructor function');
+
+        var transform = new Opacity();
+
+        api.forEach(function (method) {
+            t.ok(
+                transform[method] && transform[method].constructor === Function,
+                'Opacity should have a ' + method + ' method'
+            );
+        });
+
+        t.equal(Opacity.WORLD_CHANGED, 1, 'Opacity should have a static property WORLD_CHANGED that equals 1');
+        t.equal(Opacity.LOCAL_CHANGED, 2, 'Opacity should have a static property LOCAL_CHANGED that equals 2');
+
+        var parent = new OpacityStub();
+        transform = new Opacity(parent);
+
+        t.equal(transform.getParent(), parent, 'Opacity constructor should have its parent set to the first argument');
+
+        t.notOk(transform.isBreakPoint(), 'Transforms should not be a breakpoint by default');
+
+        t.end();
+    });
+
+    t.test('no breakpoints', function (t) {
+
+        var opacities = [];
+
+        for (var i = 0; i < 5; i++)
+            opacities.push(new Opacity(opacities[i - 1]));
+
+
+        for (i = 0; i < opacities.length; i++)
+            opacities[i].setOpacity(0.5);
+
+
+        for (i = 0; i < opacities.length; i++)
+            console.log(opacities[i])
+
+
+
+        t.end();
+    });
+    //
+    // t.test('getParent method', function (t) {
+    //
+    //     var transform = new Opacity('hello');
+    //     t.doesNotThrow(function () {
+    //         transform.getParent();
+    //     }, 'transform should be callable');
+    //
+    //     t.equal(transform.getParent(), 'hello', 'getParent should return the value passed to the constructor');
+    //     transform.setParent('bye');
+    //     t.equal(transform.getParent(), 'bye', 'getParent should return the value passed to the setParent method');
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setBreakPoint', function (t) {
+    //
+    //     var transform = new Opacity();
+    //
+    //     // sanity check
+    //     if (transform.isBreakPoint())
+    //         throw new Error('Opacity should not be a breakpoint by default.' +
+    //             ' isBreakPoint or the constructor might be broken');
+    //
+    //     t.doesNotThrow( function () {
+    //         transform.setBreakPoint();
+    //     }, 'setBreakPoint should be callable');
+    //
+    //     t.ok(transform.isBreakPoint(), 'after calling setBreakpoint, a transform should be a breakpoint');
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('isBreakPoint', function (t) {
+    //
+    //     var transform = new Opacity();
+    //
+    //     t.doesNotThrow(function () {
+    //         t.notOk(transform.isBreakPoint(), 'transforms are not a breakpoint when they are first instantiated');
+    //     }, 'isBreakPoint should be callable if the transform is not a breakpoint');
+    //
+    //     transform.setBreakPoint();
+    //
+    //     t.doesNotThrow(function () {
+    //         t.ok(transform.isBreakPoint(), 'isBreakPoint should return true when the transform is a breakpoint');
+    //     }, 'isBreakPoint should be callable if the transform is a breakpoint');
+    //
+    //     transform.reset();
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('reset method', function (t) {
+    //     var parent = new OpacityStub();
+    //     var transform = new Opacity(parent);
+    //     transform.setBreakPoint();
+    //
+    //     // sanity check
+    //     if (parent !== transform.getParent() || !transform.isBreakPoint())
+    //         throw new Error('transform.getParent or isBreakPoint is not functioning correctly');
+    //
+    //     t.doesNotThrow(transform.reset.bind(transform), 'reset should be callable without arguments');
+    //
+    //     api.forEach(function (method) {
+    //         t.notOk(parent[method].called, 'No calls should be made on the parent during reset');
+    //     });
+    //
+    //     var a = 2;
+    //     while (a--) {
+    //         t.ok(transform.getParent() == null, 'after being reset, transform should not have a parent');
+    //         t.notOk(transform.isBreakPoint(), 'after being reset, transform should not be a breakpoint');
+    //         transform = new Opacity();
+    //         transform.reset();
+    //     }
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('getLocalTransform method', function (t) {
+    //     var transform = new Opacity();
+    //     t.doesNotThrow(function () {
+    //         t.deepEqual(transform.getLocalTransform(), new Float32Array([
+    //                                                     1, 0, 0, 0,
+    //                                                     0, 1, 0, 0,
+    //                                                     0, 0, 1, 0,
+    //                                                     0, 0, 0, 1]), 'transform.getLocalTransform should return' +
+    //                                                                  ' identity matrix after instantiation');
+    //     }, 'getLocalTransform should be callable');
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('getWorldTransform method', function (t) {
+    //     var transform = new Opacity();
+    //
+    //     // sanity check
+    //     if (transform.isBreakPoint()) throw new Error('transform is reporting itself to be ' +
+    //                                                   'a breakpoint after instantiation. isBreakPoint ' +
+    //                                                   'or the constructor might be broken');
+    //
+    //     t.throws(transform.getWorldTransform.bind(transform), 'getWorldTransform should throw if ' +
+    //                                                           'the transform isn\'t a breakpoint');
+    //
+    //     transform.setBreakPoint();
+    //
+    //     t.doesNotThrow(function () {
+    //         t.deepEqual(transform.getWorldTransform(), new Float32Array([
+    //                                                     1, 0, 0, 0,
+    //                                                     0, 1, 0, 0,
+    //                                                     0, 0, 1, 0,
+    //                                                     0, 0, 0, 1]), 'transform.getWorldTransform should return' +
+    //                                                                  ' identity matrix after instantiation');
+    //     }, 'getWorldTransform should not throw if the transform is a breakpoint');
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('calculate method', function (t) {
+    //     var transform = new Opacity();
+    //
+    //     t.doesNotThrow(function () {
+    //         transform.calculate(createTestNode());
+    //         t.deepEqual(transform.getLocalTransform(), new Float32Array([
+    //                                                     1, 0, 0, 0,
+    //                                                     0, 1, 0, 0,
+    //                                                     0, 0, 1, 0,
+    //                                                     0, 0, 0, 1]), 'transform.getLocalTransform should return' +
+    //                                                                  ' identity matrix with no vectors changed');
+    //     }, '.calculate should be callable');
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setPosition method', function (t) {
+    //     var transform = new Opacity();
+    //
+    //     t.doesNotThrow( function () {
+    //         transform.setPosition(0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(0, 0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(0, 0, 0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(null, 0, 0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(null, null, 0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(null, null, null);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //         transform.setPosition(null, 0);
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'transform should not change from zero when a dimension is passed ' +
+    //                                                         'null, undefined, or zero');
+    //
+    //         transform.setPosition(0, 1);
+    //
+    //         t.deepEqual(transform.getPosition(), new Float32Array([0, 1, 0]), 'transform should set the value properly for the given dimension');
+    //
+    //     }, 'transform should be callable with any number of arguments');
+    //
+    //     transform.setPosition(1, 2, 3);
+    //
+    //     t.deepEqual(transform.getPosition(), new Float32Array([1, 2, 3]), 'transform should set the values returned by getPosition');
+    //
+    //     transform.setPosition();
+    //
+    //     t.deepEqual(transform.getPosition(), new Float32Array([1, 2, 3]), 'undefined arguments should not change the values stored');
+    //
+    //     transform.setPosition(null, null, null);
+    //
+    //     t.deepEqual(transform.getPosition(), new Float32Array([1, 2, 3]), 'null arguments should not change the values stored');
+    //
+    //     transform.setPosition(0, 0, 0);
+    //
+    //     t.deepEqual(transform.getPosition(), new Float32Array([0, 0, 0]), 'zero should successfully set the position back to zero');
+    //
+    //     var node = createTestNode();
+    //
+    //     transform.setPosition(3, 3, 3);
+    //
+    //     transform.calculate(node);
+    //
+    //     t.deepEqual(transform.getLocalTransform(), new Float32Array([
+    //                                                 1, 0, 0, 0,
+    //                                                 0, 1, 0, 0,
+    //                                                 0, 0, 1, 0,
+    //                                                 3, 3, 3, 1]), 'position should change the ' +
+    //                                                              'result of the calculated matrix');
+    //
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setRotation method', function (t) {
+    //
+    //     // todo
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setScale method', function (t) {
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setAlign method', function (t) {
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setMountPoint method', function (t) {
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('setOrigin method', function (t) {
+    //
+    //     t.end();
+    // });
+    //
+    // t.test('calculateWorldMatrix', function (t) {
+    //
+    //     t.end();
+    // });
+});

--- a/core/test/opacity/Opacity.spec.js
+++ b/core/test/opacity/Opacity.spec.js
@@ -208,10 +208,6 @@ test('Opacity class', function (t) {
             'Attempting to get the world opacity of the 4th opacity should throw an error, since no breakpoint has been set on it'
         );
 
-        for (i = 0; i < opacities.length; i++)
-            console.log(JSON.stringify(opacities[i]));
-
-
         t.end();
     });
 });

--- a/core/test/opacity/Opacity.spec.js
+++ b/core/test/opacity/Opacity.spec.js
@@ -81,133 +81,136 @@ test('Opacity class', function (t) {
             opacity.setOpacity(0.5);
         }
 
+        t.test('Root Opacity (no breakpoint): 0.5', function(t) {
+            t.equal(
+                opacities[0].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
+                'Calculating the root opacity should only change the local opacity'
+            );
+            t.equal(
+                opacities[0].getLocalOpacity(), 0.5,
+                'The root local opacity should be set to 0.5'
+            );
 
-        t.comment('Root Opacity (no breakpoint): 0.5');
+            t.equal(
+                opacities[0].getOpacity(), 0.5,
+                'The root opacity should still be set to 0.5 after calculation'
+            );
+            t.throws(
+                function() {
+                    opacities[0].getWorldOpacity();
+                },
+                /not calculating world transforms/,
+                'Attempting to get the world opacity of the root opacity should throw an error, since no breakpoint has been set on it'
+            );
 
-        t.equal(
-            opacities[0].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
-            'Calculating the root opacity should only change the local opacity'
-        );
-        t.equal(
-            opacities[0].getLocalOpacity(), 0.5,
-            'The root local opacity should be set to 0.5'
-        );
+            t.end();
+        });
 
-        t.equal(
-            opacities[0].getOpacity(), 0.5,
-            'The root opacity should still be set to 0.5 after calculation'
-        );
-        t.throws(
-            function() {
-                opacities[0].getWorldOpacity();
-            },
-            /not calculating world transforms/,
-            'Attempting to get the world opacity of the root opacity should throw an error, since no breakpoint has been set on it'
-        );
+        t.test('2nd Opacity (no breakpoint): 0.5', function(t) {
+            t.equal(
+                opacities[1].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
+                'Calculating the 2nd opacity (child of root) should only change the local opacity, since no breakpoint has been set on it'
+            );
+            t.equal(
+                opacities[1].getLocalOpacity(), 0.25,
+                'The 2nd opacity should have been multiplied with the root opacity'
+            );
 
+            t.equal(
+                opacities[1].getOpacity(), 0.5,
+                'The 2nd opacity should still be set to 0.5 after calculation'
+            );
+            t.throws(
+                function() {
+                    opacities[1].getWorldOpacity();
+                },
+                /not calculating world transforms/,
+                'Attempting to get the world opacity of the 2nd opacity should throw an error, since no breakpoint has been set on it'
+            );
 
-        t.comment('2nd Opacity (no breakpoint): 0.5');
+            t.end();
+        });
 
-        t.equal(
-            opacities[1].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
-            'Calculating the 2nd opacity (child of root) should only change the local opacity, since no breakpoint has been set on it'
-        );
-        t.equal(
-            opacities[1].getLocalOpacity(), 0.25,
-            'The 2nd opacity should have been multiplied with the root opacity'
-        );
+        t.test('3rd Opacity (no breakpoint): 0.5', function(t) {
+            t.equal(
+                opacities[2].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
+                'Calculating the 3rd opacity should only change the local opacity, since no breakpoint has been set on it'
+            );
+            t.equal(
+                opacities[2].getLocalOpacity(), 0.125,
+                'The 3rd opacity should have been multiplied with the root and 2nd opacity'
+            );
 
-        t.equal(
-            opacities[1].getOpacity(), 0.5,
-            'The 2nd opacity should still be set to 0.5 after calculation'
-        );
-        t.throws(
-            function() {
-                opacities[1].getWorldOpacity();
-            },
-            /not calculating world transforms/,
-            'Attempting to get the world opacity of the 2nd opacity should throw an error, since no breakpoint has been set on it'
-        );
+            t.equal(
+                opacities[2].getOpacity(), 0.5,
+                'The 3rd opacity should still be set to 0.5 after calculation'
+            );
+            t.throws(
+                function() {
+                    opacities[2].getWorldOpacity();
+                },
+                /not calculating world transforms/,
+                'Attempting to get the world opacity of the 3rd opacity should throw an error, since no breakpoint has been set on it'
+            );
 
+            t.end();
+        });
 
-        t.comment('3rd Opacity (no breakpoint): 0.5');
+        t.test('4th Opacity (breakpoint): 0.5', function(t) {
+            opacities[3].setBreakPoint();
+            t.equal(
+                opacities[3].calculate(), Opacity.LOCAL_CHANGED | Opacity.WORLD_CHANGED,
+                'Calculating the 4th opacity should have checked if the world opacity changed, since it has a breakpoint set on it'
+            );
 
-        t.equal(
-            opacities[2].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
-            'Calculating the 3rd opacity should only change the local opacity, since no breakpoint has been set on it'
-        );
-        t.equal(
-            opacities[2].getLocalOpacity(), 0.125,
-            'The 3rd opacity should have been multiplied with the root and 2nd opacity'
-        );
+            t.equal(
+                opacities[3].isBreakPoint(), true,
+                'The 4th opacity should still have breakpoint after calculation'
+            );
+            t.equal(
+                opacities[3].getLocalOpacity(), 0.0625,
+                'The 4th local opacity should have been multiplied with the root, 2nd and 3rd opacity'
+            );
+            t.equal(
+                opacities[3].getOpacity(), 0.5,
+                'The 4th opacity should still be set to 0.5 after calculation'
+            );
+            t.doesNotThrow(function() {
+                opacities[3].getWorldOpacity();
+            }, 'Attempting to calculate the world on the 4th opacity should not throw an error, since a breakpoint has been set on it');
 
-        t.equal(
-            opacities[2].getOpacity(), 0.5,
-            'The 3rd opacity should still be set to 0.5 after calculation'
-        );
-        t.throws(
-            function() {
-                opacities[2].getWorldOpacity();
-            },
-            /not calculating world transforms/,
-            'Attempting to get the world opacity of the 3rd opacity should throw an error, since no breakpoint has been set on it'
-        );
+            t.equal(
+                opacities[3].getWorldOpacity(), 0.0625,
+                'The 4th world opacity should be have been multiplied with all previous opacities'
+            );
 
+            t.end();
+        });
 
-        t.comment('4th Opacity (breakpoint): 0.5');
+        t.test('5th Opacity (no breakpoint): 0.5', function(t) {
+            t.equal(
+                opacities[4].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
+                'Calculating the 5th opacity should only change the local opacity, since no breakpoint has been set on it'
+            );
+            t.equal(
+                opacities[4].getLocalOpacity(), 0.5,
+                'The 5th local opacity should be equivalent to the opacity set on it, it should not have been multiplied, since the 4th node has a breakpoint set on it'
+            );
 
-        opacities[3].setBreakPoint();
-        t.equal(
-            opacities[3].calculate(), Opacity.LOCAL_CHANGED | Opacity.WORLD_CHANGED,
-            'Calculating the 4th opacity should have checked if the world opacity changed, since it has a breakpoint set on it'
-        );
+            t.equal(
+                opacities[4].getOpacity(), 0.5,
+                'The 5th opacity should still be set to 0.5 after calculation'
+            );
 
-        t.equal(
-            opacities[3].isBreakPoint(), true,
-            'The 4th opacity should still have breakpoint after calculation'
-        );
-        t.equal(
-            opacities[3].getLocalOpacity(), 0.0625,
-            'The 4th local opacity should have been multiplied with the root, 2nd and 3rd opacity'
-        );
-        t.equal(
-            opacities[3].getOpacity(), 0.5,
-            'The 4th opacity should still be set to 0.5 after calculation'
-        );
-        t.doesNotThrow(function() {
-            opacities[3].getWorldOpacity();
-        }, 'Attempting to calculate the world on the 4th opacity should not throw an error, since a breakpoint has been set on it');
+            t.throws(
+                function() {
+                    opacities[4].getWorldOpacity();
+                },
+                /not calculating world transforms/,
+                'Attempting to get the world opacity of the 4th opacity should throw an error, since no breakpoint has been set on it'
+            );
 
-        t.equal(
-            opacities[3].getWorldOpacity(), 0.0625,
-            'The 4th world opacity should be have been multiplied with all previous opacities'
-        );
-
-
-        t.comment('5th Opacity (no breakpoint): 0.5')
-
-        t.equal(
-            opacities[4].calculate(), Opacity.LOCAL_CHANGED & ~Opacity.WORLD_CHANGED,
-            'Calculating the 5th opacity should only change the local opacity, since no breakpoint has been set on it'
-        );
-        t.equal(
-            opacities[4].getLocalOpacity(), 0.5,
-            'The 5th local opacity should be equivalent to the opacity set on it, it should not have been multiplied, since the 4th node has a breakpoint set on it'
-        );
-
-        t.equal(
-            opacities[4].getOpacity(), 0.5,
-            'The 5th opacity should still be set to 0.5 after calculation'
-        );
-
-        t.throws(
-            function() {
-                opacities[4].getWorldOpacity();
-            },
-            /not calculating world transforms/,
-            'Attempting to get the world opacity of the 4th opacity should throw an error, since no breakpoint has been set on it'
-        );
-
-        t.end();
+            t.end();
+        });
     });
 });

--- a/core/test/opacity/Opacity.spec.js
+++ b/core/test/opacity/Opacity.spec.js
@@ -28,8 +28,6 @@ var test = require('tape');
 var api = require('./Opacity.api');
 var Opacity = require('../../Opacity');
 var OpacityStub = require('./Opacity.stub');
-var NodeStub = require('../node/Node.stub');
-var sinon = require('sinon');
 
 test('Opacity class', function (t) {
 

--- a/core/test/opacity/Opacity.stub.js
+++ b/core/test/opacity/Opacity.stub.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var api = require('./Opacity.api');
+var sinon = require('sinon');
+
+function Opacity (parent) {
+    api.forEach(function (method) {
+        this[method] = sinon.stub();
+    }.bind(this));
+}
+
+module.exports = Opacity;

--- a/core/test/opacity/Opacity.stub.js
+++ b/core/test/opacity/Opacity.stub.js
@@ -1,3 +1,27 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Famous Industries Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 'use strict';
 
 var api = require('./Opacity.api');

--- a/core/test/opacitySystem/OpacitySystem.api.js
+++ b/core/test/opacitySystem/OpacitySystem.api.js
@@ -1,0 +1,15 @@
+module.exports = [
+    'reset',
+    'setParent',
+    'getParent',
+    'setBreakPoint',
+    'isBreakPoint',
+    'getLocalOpacity',
+    'getWorldOpacity',
+    'calculate',
+    'getOpacity',
+    'setOpacity',
+    'calculateWorldOpacity',
+    'fromNode',
+    'fromNodeWithParent'
+];

--- a/core/test/opacitySystem/OpacitySystem.stub.js
+++ b/core/test/opacitySystem/OpacitySystem.stub.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var api = require('./OpacitySystem.api');
+var sinon = require('sinon');
+
+var OpacitySystem = {};
+
+api.forEach(function (method) {
+    OpacitySystem[method] = sinon.stub();
+});
+
+module.exports = OpacitySystem;

--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -26,6 +26,7 @@
 
 var CallbackStore = require('../utilities/CallbackStore');
 var TransformSystem = require('../core/TransformSystem');
+var OpacitySystem = require('../core/OpacitySystem');
 var Commands = require('../core/Commands');
 var Size = require('../core/Size');
 
@@ -79,7 +80,6 @@ function DOMElement(node, options) {
     this._callbacks = new CallbackStore();
 
     this.setProperty('display', node.isShown() ? 'block' : 'none');
-    this.onOpacityChange(node.getOpacity());
 
     if (!options) return;
 

--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -172,6 +172,7 @@ DOMElement.prototype.onMount = function onMount(node, id) {
     this._UIEvents = node.getUIEvents().slice(0);
     TransformSystem.makeBreakPointAt(node.getLocation());
     this.onSizeModeChange.apply(this, node.getSizeMode());
+    OpacitySystem.makeBreakPointAt(node.getLocation());
     this.draw();
     this.setAttribute('data-fa-path', node.getLocation());
 };
@@ -291,6 +292,8 @@ DOMElement.prototype.onSizeChange = function onSizeChange(x, y) {
  * @return {DOMElement} this
  */
 DOMElement.prototype.onOpacityChange = function onOpacityChange(opacity) {
+    opacity = opacity.getLocalOpacity();
+
     return this.setProperty('opacity', opacity);
 };
 
@@ -468,6 +471,7 @@ DOMElement.prototype.init = function init () {
     this._changeQueue.push(Commands.INIT_DOM, this._tagName);
     this._initialized = true;
     this.onTransformChange(TransformSystem.get(this._node.getLocation()));
+    this.onOpacityChange(OpacitySystem.get(this._node.getLocation()));
     var size = this._node.getSize();
     this.onSizeChange(size[0], size[1]);
     if (!this._requestingUpdate) this._requestUpdate();

--- a/webgl-renderables/Mesh.js
+++ b/webgl-renderables/Mesh.js
@@ -509,7 +509,7 @@ Mesh.prototype.onMount = function onMount (node, id) {
     this._id = id;
 
     TransformSystem.makeCalculateWorldMatrixAt(node.getLocation());
-    OpacitySystem.makeBreakPointAt(node.getLocation());
+    OpacitySystem.makeCalculateWorldOpacityAt(node.getLocation());
 
     this.draw();
 };

--- a/webgl-renderables/Mesh.js
+++ b/webgl-renderables/Mesh.js
@@ -31,6 +31,7 @@ var Geometry = require('../webgl-geometries');
 var Commands = require('../core/Commands');
 var TransformSystem = require('../core/TransformSystem');
 var Plane = require('../webgl-geometries/primitives/Plane');
+var OpacitySystem = require('../core/OpacitySystem');
 
 /**
  * The Mesh class is responsible for providing the API for how
@@ -508,6 +509,7 @@ Mesh.prototype.onMount = function onMount (node, id) {
     this._id = id;
 
     TransformSystem.makeCalculateWorldMatrixAt(node.getLocation());
+    OpacitySystem.makeBreakPointAt(node.getLocation());
 
     this.draw();
 };
@@ -613,7 +615,7 @@ Mesh.prototype.onOpacityChange = function onOpacityChange (opacity) {
     if (this._initialized) {
         this._changeQueue.push(Commands.GL_UNIFORMS);
         this._changeQueue.push('u_opacity');
-        this._changeQueue.push(opacity);
+        this._changeQueue.push(opacity.getWorldOpacity());
     }
 
     this._requestUpdate();
@@ -656,9 +658,9 @@ Mesh.prototype._requestUpdate = function _requestUpdate () {
 Mesh.prototype.init = function init () {
     this._initialized = true;
     this.onTransformChange(TransformSystem.get(this._node.getLocation()));
+    this.onOpacityChange(OpacitySystem.get(this._node.getLocation()));
     var size = this._node.getSize();
     this.onSizeChange(size[0], size[1], size[2]);
-    this.onOpacityChange(this._node.getOpacity());
     this._requestUpdate();
 };
 


### PR DESCRIPTION
## Example

```javascript
'use strict';

var DOMElement = require('famous/dom-renderables/DOMElement');
var FamousEngine = require('famous/core/FamousEngine');

FamousEngine.init();

var node = FamousEngine.createScene();

node = node.addChild();
node.setOpacity(0.7);

node = node.addChild();
node.setOpacity(0.7);

node = node.addChild();
node.setSizeMode('absolute', 'absolute').setAbsoluteSize(100, 100);
new DOMElement(node, { properties: { background: 'red' }, content: '0.7 opacity (two non-DOMElements as parents)' });
node.setOpacity(0.7)

node = node.addChild();
node.setOpacity(0.7);

node = node.addChild();
node.setSizeMode('absolute', 'absolute').setAbsoluteSize(100, 100).setPosition(100);
new DOMElement(node, { properties: { background: 'red' }, content: '0.7 opacity (child of first DOMElement with Node in between)' });
node.setOpacity(0.7);
```

Before: https://api-te.famo.us/codemanager/v1/containers/36326067-c17d-48a7-84fd-5e40a1876682/share

After: https://api-te.famo.us/codemanager/v1/containers/0a8b9cde-17b0-48d3-84d1-4125dc5ccd55/share

There is currently some redundant logic in OpacitySystem and TransformSystem. Thoughts on having a `System` class to inherit from?

Submitted for review.

@DnMllr 


@redwoodfavorite Is opacity currently being handled correctly for Meshes?There haven't been big changes to onOpacityChange (just uses `opacity.getWorldOpacity()` now), but setting opacities on meshes also fails with current develop. Is this a known issue?