### PR TITLE
test: Add test-case for man in the middle insertion

### DIFF
--- a/dom-renderers/test/DOMRenderer.js
+++ b/dom-renderers/test/DOMRenderer.js
@@ -330,7 +330,6 @@ test('DOMRenderer', function(t) {
         t.equal(element.children[0].children[1].children.length, 0, 'domRenderer.insertEl should insert sibling as leaf node');
 
         domRenderer.loadPath('selector/0');
-
         domRenderer.setContent('hello world');
 
         t.equal(element.children[0].children.length, 3, 'domRenderer.insertEl should preserve correct DOM nesting when wrapping content');


### PR DESCRIPTION
Currently failing test case that shows that man-in-the-middle insertion is broken. Broken out of #276 . Used to work when we had `findChildren`.

@DnMllr 