### PR TITLE
Fix node sizing

### DIFF
--- a/core/Node.js
+++ b/core/Node.js
@@ -95,14 +95,16 @@ function Node () {
     this._transformID = null;
     this._sizeID = null;
 
+    // initialize defaults on the constructor directly
+    // this will allow subclasses to inherit defaults
+    this.constructor.RELATIVE_SIZE = 0;
+    this.constructor.ABSOLUTE_SIZE = 1;
+    this.constructor.RENDER_SIZE = 2;
+    this.constructor.DEFAULT_SIZE = 0;
+    this.constructor.NO_DEFAULT_COMPONENTS = false;
+
     if (!this.constructor.NO_DEFAULT_COMPONENTS) this._init();
 }
-
-Node.RELATIVE_SIZE = 0;
-Node.ABSOLUTE_SIZE = 1;
-Node.RENDER_SIZE = 2;
-Node.DEFAULT_SIZE = 0;
-Node.NO_DEFAULT_COMPONENTS = false;
 
 /**
  * Protected method. Initializes a node with a default Transform and Size component

--- a/core/Node.js
+++ b/core/Node.js
@@ -101,7 +101,8 @@ function Node () {
     this.constructor.ABSOLUTE_SIZE = 1;
     this.constructor.RENDER_SIZE = 2;
     this.constructor.DEFAULT_SIZE = 0;
-    this.constructor.NO_DEFAULT_COMPONENTS = false;
+    if (this.constructor.NO_DEFAULT_COMPONENTS === undefined)
+        this.constructor.NO_DEFAULT_COMPONENTS = false;
 
     if (!this.constructor.NO_DEFAULT_COMPONENTS) this._init();
 }

--- a/core/Node.js
+++ b/core/Node.js
@@ -95,8 +95,8 @@ function Node () {
     this._transformID = null;
     this._sizeID = null;
 
-    // initialize defaults on the constructor directly
-    // this will allow subclasses to inherit defaults
+    // initialize constants on the constructor directly
+    // this will allow subclasses to inherit default values
     this.constructor.RELATIVE_SIZE = 0;
     this.constructor.ABSOLUTE_SIZE = 1;
     this.constructor.RENDER_SIZE = 2;

--- a/core/Scene.js
+++ b/core/Scene.js
@@ -50,6 +50,9 @@ function Scene (selector, updater) {
     if (!selector) throw new Error('Scene needs to be created with a DOM selector');
     if (!updater) throw new Error('Scene needs to be created with a class like Famous');
 
+    // The scene itself should not have a size
+    this.constructor.NO_DEFAULT_COMPONENTS = true;
+
     Node.call(this);         // Scene inherits from node
 
     this._globalUpdater = updater; // The updater that will both


### PR DESCRIPTION
This PR addresses an issue where the node does not size correctly because the scene is picking up the size instead of the Node.  The Scene itself should not have a size since it is just an abstraction layer.

The fix involves placing the constant definitions within the constructor itself as defined in #353.  Since the original constant `INIT` had a value of `true`, it was only by chance that this working.  (I think... )

This could also be wrong, and the scene need sizing for something else, but this addresses the proportional sizing issues...