### PR TITLE
Remove context div

### DIFF
--- a/renderers/Compositor.js
+++ b/renderers/Compositor.js
@@ -266,8 +266,13 @@ Compositor.prototype.receiveCommands = function receiveCommands(commands) {
  */
 Compositor.prototype.giveSizeFor = function giveSizeFor(iterator, commands) {
     var selector = commands[iterator];
-    var size = this.getOrSetContext(selector).getRootSize();
-    this.sendResize(selector, size);
+    var context = this.getContext(selector);
+    if (context) {
+        var size = context.getRootSize();
+        this.sendResize(selector, size);
+    } else {
+        this.getOrSetContext(selector);
+    }
 };
 
 /**


### PR DESCRIPTION
When a scene creates a context, it creates an unnecessary div nested under the selector element.  By processing the size before setting the `display` to `none`, this `div` is not required.

This also addresses #361 