### PR TITLE
Decorate constructors so subclasses work, and they can define their own settings with Node being the source of default settings.

### DIFF
--- a/core/Node.js
+++ b/core/Node.js
@@ -95,6 +95,17 @@ function Node () {
     this._transformID = null;
     this._sizeID = null;
 
+    if (typeof this.constructor.RELATIVE_SIZE === 'undefined')
+        this.constructor.RELATIVE_SIZE = Node.RELATIVE_SIZE;
+    if (typeof this.constructor.ABSOLUTE_SIZE === 'undefined')
+        this.constructor.ABSOLUTE_SIZE = Node.ABSOLUTE_SIZE;
+    if (typeof this.constructor.RENDER_SIZE === 'undefined')
+        this.constructor.RENDER_SIZE = Node.RENDER_SIZE;
+    if (typeof this.constructor.DEFAULT_SIZE === 'undefined')
+        this.constructor.DEFAULT_SIZE = Node.DEFAULT_SIZE;
+    if (typeof this.constructor.NO_DEFAULT_COMPONENTS === 'undefined')
+        this.constructor.NO_DEFAULT_COMPONENTS = Node.NO_DEFAULT_COMPONENTS;
+
     if (!this.constructor.NO_DEFAULT_COMPONENTS) this._init();
 }
 


### PR DESCRIPTION
@alexanderGugel @jd-carroll @DnMllr 