### PR TITLE
breaks: Emit Dispatch#dispatch events on source node

### DIFF
--- a/core/Dispatch.js
+++ b/core/Dispatch.js
@@ -327,7 +327,7 @@ Dispatch.prototype.dispatch = function dispatch (path, event, payload) {
     
     if (!node) return;
 
-    this.addChildrenToQueue(node);
+    this._queue.push(node);
     var child;
 
     while ((child = this.breadthFirstNext()))


### PR DESCRIPTION
Addresses #366

This change is intended to make the behavior of Dispatch#dispatch more
intuitive behavior by dispatching the event on the original "source node"
(the passed in node).