### PR TITLE
break: Make names of update methods of systems consistent

### DIFF
--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -151,7 +151,7 @@ FamousEngine.prototype._update = function _update () {
     this._messages[1] = time;
 
     SizeSystem.update();
-    TransformSystem.onUpdate();
+    TransformSystem.update();
 
     while (nextQueue.length) queue.unshift(nextQueue.pop());
 

--- a/core/TransformSystem.js
+++ b/core/TransformSystem.js
@@ -125,16 +125,16 @@ TransformSystem.prototype.get = function get (path) {
 };
 
 /**
- * onUpdate is called when the transform system requires an update.
+ * update is called when the transform system requires an update.
  * It traverses the transform array and evaluates the necessary transforms
  * in the scene graph with the information from the corresponding node
  * in the scene graph
  *
- * @method onUpdate
+ * @method update
  *
  * @return {undefined} undefined
  */
-TransformSystem.prototype.onUpdate = function onUpdate () {
+TransformSystem.prototype.update = function update () {
     var transforms = this.pathStore.getItems();
     var paths = this.pathStore.getPaths();
     var transform;


### PR DESCRIPTION
The update method of the TransformSystem is called `onUpdate`, while the SizeSystem's update method  is named `update`. This presents an inconsistency.