### PR TITLE
Refactor core to no longer use singletons

### DIFF
--- a/components/Size.js
+++ b/components/Size.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,7 +25,6 @@
 'use strict';
 
 var Transitionable = require('../transitions/Transitionable');
-var SizeSystem = require('../core/SizeSystem');
 
 /**
  * Size component used for managing the size of the Node it is attached to.
@@ -129,7 +128,7 @@ Size.prototype.toString = function toString() {
  */
 Size.prototype.getValue = function getValue() {
     return {
-        sizeMode: SizeSystem.get(this._node.getLocation()).getSizeMode(),
+        sizeMode: this._node._sizeSystem.get(this._node.getLocation()).getSizeMode(),
         absolute: {
             x: this._absolute.x.get(),
             y: this._absolute.y.get(),

--- a/core/Dispatch.js
+++ b/core/Dispatch.js
@@ -31,11 +31,13 @@ var PathUtils = require('./Path');
  * The Dispatch class is used to propogate events down the
  * scene graph.
  *
- * @class Dispatch
- * @param {Scene} context The context on which it operates
- * @constructor
+ * @class
+ *
+ * @param {FamousEngine} updater The updater to be exposed to potential nodes.
  */
-function Dispatch () {
+function Dispatch (updater) {
+    this._updater = updater;
+    
     this._nodes = {}; // a container for constant time lookup of nodes
 
     this._queue = []; // The queue is used for two purposes
@@ -61,7 +63,8 @@ function Dispatch () {
 Dispatch.prototype._setUpdater = function _setUpdater (updater) {
     this._updater = updater;
 
-    for (var key in this._nodes) this._nodes[key]._setUpdater(updater);
+    for (var key in this._nodes)
+        this._nodes[key]._setUpdater(updater);
 };
 
 /**
@@ -125,7 +128,6 @@ Dispatch.prototype.mount = function mount (path, node) {
     if (this._nodes[path])
         throw new Error('Dispatch: there is a node already registered at: ' + path);
 
-    node._setUpdater(this._updater);
     this._nodes[path] = node;
     var parentPath = PathUtils.parent(path);
 
@@ -137,6 +139,8 @@ Dispatch.prototype.mount = function mount (path, node) {
                 'Parent to path: ' + path +
                 ' doesn\'t exist at expected path: ' + parentPath
         );
+
+    node._setUpdater(this._updater);
 
     var children = node.getChildren();
     var components = node.getComponents();
@@ -407,4 +411,4 @@ function _splitTo (string, target) {
     return target;
 }
 
-module.exports = new Dispatch();
+module.exports = Dispatch;

--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -49,8 +49,12 @@ var TIME_UPDATE = [Commands.TIME, null];
  */
 function FamousEngine() {
     var _this = this;
+    
+    this._dispatch = new Dispatch(this);
 
-    Dispatch._setUpdater(this);
+    this._sizeSystem = new SizeSystem(this._dispatch);
+
+    this._transformSystem = new TransformSystem(this._dispatch);
 
     this._updateQueue = []; // The updateQueue is a place where nodes
                             // can place themselves in order to be
@@ -75,13 +79,11 @@ function FamousEngine() {
     this._clock = new Clock(); // a clock to keep track of time for the scene
                                // graph.
 
-
     this._channel = new Channel();
     this._channel.onMessage = function (message) {
         _this.handleMessage(message);
     };
 }
-
 
 /**
  * An init script that initializes the FamousEngine with options
@@ -150,8 +152,8 @@ FamousEngine.prototype._update = function _update () {
 
     this._messages[1] = time;
 
-    SizeSystem.update();
-    TransformSystem.update();
+    this._sizeSystem.update();
+    this._transformSystem.onUpdate();
 
     while (nextQueue.length) queue.unshift(nextQueue.pop());
 
@@ -255,7 +257,7 @@ FamousEngine.prototype.handleWith = function handleWith (messages) {
         case Commands.TRIGGER: // the TRIGGER command sends a UIEvent to the specified path
             var type = messages.shift();
             var ev = messages.shift();
-            Dispatch.dispatchUIEvent(path, type, ev);
+            this._dispatch.dispatchUIEvent(path, type, ev);
             break;
         default:
             throw new Error('received unknown command: ' + command);

--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -153,7 +153,7 @@ FamousEngine.prototype._update = function _update () {
     this._messages[1] = time;
 
     this._sizeSystem.update();
-    this._transformSystem.onUpdate();
+    this._transformSystem.update();
 
     while (nextQueue.length) queue.unshift(nextQueue.pop());
 

--- a/core/Scene.js
+++ b/core/Scene.js
@@ -29,8 +29,6 @@
 var Node = require('./Node');
 var Dispatch = require('./Dispatch');
 var Commands = require('./Commands');
-var TransformSystem = require('./TransformSystem');
-var SizeSystem = require('./SizeSystem');
 
 /**
  * Scene is the bottom of the scene graph. It is its own
@@ -50,6 +48,8 @@ var SizeSystem = require('./SizeSystem');
 function Scene (selector, updater) {
     if (!selector) throw new Error('Scene needs to be created with a DOM selector');
     if (!updater) throw new Error('Scene needs to be created with a class like Famous');
+
+    this._setUpdater(updater);
 
     Node.call(this);         // Scene inherits from node
 
@@ -142,12 +142,12 @@ Scene.prototype.onReceive = function onReceive (event, payload) {
 Scene.prototype.mount = function mount (path) {
     if (this.isMounted())
         throw new Error('Scene is already mounted at: ' + this.getLocation());
-    Dispatch.mount(path, this);
+    this._dispatch.mount(path, this);
     this._id = path;
     this._mounted = true;
     this._parent = this;
-    TransformSystem.registerTransformAtPath(path);
-    SizeSystem.registerSizeAtPath(path);
+    this._transformSystem.registerTransformAtPath(path);
+    this._sizeSystem.registerSizeAtPath(path);
 };
 
 module.exports = Scene;

--- a/core/SizeSystem.js
+++ b/core/SizeSystem.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,7 +26,6 @@
 
 var PathStore = require('./PathStore');
 var Size = require('./Size');
-var Dispatch = require('./Dispatch');
 var PathUtils = require('./Path');
 
 /**
@@ -34,9 +33,12 @@ var PathUtils = require('./Path');
  * It holds size components and operates upon them.
  *
  * @constructor
+ * @param {Dispatch} dispatch The dispatch object to be used for accessing
+ *                            nodes.
  */
-function SizeSystem () {
+function SizeSystem (dispatch) {
     this.pathStore = new PathStore();
+    this._dispatch = dispatch;
 }
 
 /**
@@ -109,7 +111,7 @@ SizeSystem.prototype.update = function update () {
     var components;
 
     for (i = 0, len = sizes.length ; i < len ; i++) {
-        node = Dispatch.getNode(paths[i]);
+        node = this._dispatch.getNode(paths[i]);
         components = node.getComponents();
         if (!node) continue;
         size = sizes[i];
@@ -268,4 +270,4 @@ function sizeChanged (node, components, size) {
     size.sizeChanged = false;
 }
 
-module.exports = new SizeSystem();
+module.exports = SizeSystem;

--- a/core/SizeSystem.js
+++ b/core/SizeSystem.js
@@ -37,9 +37,12 @@ var PathUtils = require('./Path');
  *                            nodes.
  */
 function SizeSystem (dispatch) {
-    this.pathStore = new PathStore();
+    PathStore.call(this);
     this._dispatch = dispatch;
 }
+
+SizeSystem.prototype = Object.create(PathStore.prototype);
+SizeSystem.prototype.constructor = SizeSystem;
 
 /**
  * Registers a size component to a give path. A size component can be passed as the second argument
@@ -53,9 +56,9 @@ function SizeSystem (dispatch) {
  * @return {undefined} undefined
  */
 SizeSystem.prototype.registerSizeAtPath = function registerSizeAtPath (path, size) {
-    if (!PathUtils.depth(path)) return this.pathStore.insert(path, size ? size : new Size());
+    if (!PathUtils.depth(path)) return this.insert(path, size ? size : new Size());
 
-    var parent = this.pathStore.get(PathUtils.parent(path));
+    var parent = this.get(PathUtils.parent(path));
 
     if (!parent) throw new Error(
             'No parent size registered at expected path: ' + PathUtils.parent(path)
@@ -63,7 +66,7 @@ SizeSystem.prototype.registerSizeAtPath = function registerSizeAtPath (path, siz
 
     if (size) size.setParent(parent);
 
-    this.pathStore.insert(path, size ? size : new Size(parent));
+    this.insert(path, size ? size : new Size(parent));
 };
 
 /**
@@ -71,28 +74,24 @@ SizeSystem.prototype.registerSizeAtPath = function registerSizeAtPath (path, siz
  * path
  *
  * @method
+ * @alias remove
  *
  * @param {String} path The path at which to remove the size.
  *
  * @return {undefined} undefined
  */
-SizeSystem.prototype.deregisterSizeAtPath = function deregisterSizeAtPath(path) {
-    this.pathStore.remove(path);
-};
+SizeSystem.prototype.deregisterSizeAtPath = SizeSystem.prototype.remove;
 
 /**
  * Returns the size component stored at a given path. Returns undefined if no
  * size component is registered to that path.
  *
- * @method
+ * @method get
  *
  * @param {String} path The path at which to get the size component.
  *
  * @return {undefined} undefined
  */
-SizeSystem.prototype.get = function get (path) {
-    return this.pathStore.get(path);
-};
 
 /**
  * Updates the sizes in the scene graph. Called internally by the famous engine.
@@ -102,8 +101,8 @@ SizeSystem.prototype.get = function get (path) {
  * @return {undefined} undefined
  */
 SizeSystem.prototype.update = function update () {
-    var sizes = this.pathStore.getItems();
-    var paths = this.pathStore.getPaths();
+    var sizes = this.getItems();
+    var paths = this.getPaths();
     var node;
     var size;
     var i;
@@ -123,8 +122,6 @@ SizeSystem.prototype.update = function update () {
         if (size.fromComponents(components)) sizeChanged(node, components, size);
     }
 };
-
-// private methods
 
 /**
  * Private method to alert the node and components that size mode changed.

--- a/core/TransformSystem.js
+++ b/core/TransformSystem.js
@@ -37,9 +37,12 @@ var PathStore = require('./PathStore');
  *                            nodes.
   */
 function TransformSystem (dispatch) {
-    this.pathStore = new PathStore();
+    PathStore.call(this);
     this._dispatch = dispatch;
 }
+
+TransformSystem.prototype = Object.create(PathStore.prototype);
+TransformSystem.prototype.constructor = TransformSystem;
 
 /**
  * registers a new Transform for the given path. This transform will be updated
@@ -53,9 +56,9 @@ function TransformSystem (dispatch) {
  */
 TransformSystem.prototype.registerTransformAtPath = function registerTransformAtPath (path, transform) {
     if (!PathUtils.depth(path))
-        return this.pathStore.insert(path, transform ? transform : new Transform());
+        return this.insert(path, transform ? transform : new Transform());
 
-    var parent = this.pathStore.get(PathUtils.parent(path));
+    var parent = this.get(PathUtils.parent(path));
 
     if (!parent) throw new Error(
             'No parent transform registered at expected path: ' + PathUtils.parent(path)
@@ -63,7 +66,7 @@ TransformSystem.prototype.registerTransformAtPath = function registerTransformAt
 
     if (transform) transform.setParent(parent);
 
-    this.pathStore.insert(path, transform ? transform : new Transform(parent));
+    this.insert(path, transform ? transform : new Transform(parent));
 };
 
 /**
@@ -71,12 +74,11 @@ TransformSystem.prototype.registerTransformAtPath = function registerTransformAt
  *
  * @method deregisterTransformAtPath
  * @return {void}
+ * @alias remove
  *
  * @param {String} path at which to register the transform
  */
-TransformSystem.prototype.deregisterTransformAtPath = function deregisterTransformAtPath (path) {
-    this.pathStore.remove(path);
-};
+TransformSystem.prototype.deregisterTransformAtPath = TransformSystem.prototype.remove;
 
 /**
  * Method which will make the transform currently stored at the given path a breakpoint.
@@ -92,7 +94,7 @@ TransformSystem.prototype.deregisterTransformAtPath = function deregisterTransfo
  * @return {undefined} undefined
  */
 TransformSystem.prototype.makeBreakPointAt = function makeBreakPointAt (path) {
-    var transform = this.pathStore.get(path);
+    var transform = this.get(path);
     if (!transform) throw new Error('No transform Registered at path: ' + path);
     transform.setBreakPoint();
 };
@@ -107,7 +109,7 @@ TransformSystem.prototype.makeBreakPointAt = function makeBreakPointAt (path) {
  * @return {undefined} undefined
  */
 TransformSystem.prototype.makeCalculateWorldMatrixAt = function makeCalculateWorldMatrixAt (path) {
-        var transform = this.pathStore.get(path);
+        var transform = this.get(path);
         if (!transform) throw new Error('No transform Registered at path: ' + path);
         transform.setCalculateWorldMatrix();
 };
@@ -116,15 +118,12 @@ TransformSystem.prototype.makeCalculateWorldMatrixAt = function makeCalculateWor
  * Returns the instance of the transform class associated with the given path,
  * or undefined if no transform is associated.
  *
- * @method
+ * @method get
  *
  * @param {String} path The path to lookup
  *
  * @return {Transform | undefined} the transform at that path is available, else undefined.
  */
-TransformSystem.prototype.get = function get (path) {
-    return this.pathStore.get(path);
-};
 
 /**
  * update is called when the transform system requires an update.
@@ -137,8 +136,8 @@ TransformSystem.prototype.get = function get (path) {
  * @return {undefined} undefined
  */
 TransformSystem.prototype.update = function update () {
-    var transforms = this.pathStore.getItems();
-    var paths = this.pathStore.getPaths();
+    var transforms = this.getItems();
+    var paths = this.getPaths();
     var transform;
     var changed;
     var node;
@@ -166,8 +165,6 @@ TransformSystem.prototype.update = function update () {
         }
     }
 };
-
-// private methods
 
 /**
  * Private method to call when align changes. Triggers 'onAlignChange' methods

--- a/core/TransformSystem.js
+++ b/core/TransformSystem.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,17 +26,19 @@
 
 var PathUtils = require('./Path');
 var Transform = require('./Transform');
-var Dispatch = require('./Dispatch');
 var PathStore = require('./PathStore');
 
 /**
  * The transform class is responsible for calculating the transform of a particular
  * node from the data on the node and its parent
  *
- * @constructor {TransformSystem}
- */
-function TransformSystem () {
+ * @constructor
+ * @param {Dispatch} dispatch The dispatch object to be used for accessing
+ *                            nodes.
+  */
+function TransformSystem (dispatch) {
     this.pathStore = new PathStore();
+    this._dispatch = dispatch;
 }
 
 /**
@@ -115,7 +117,7 @@ TransformSystem.prototype.makeCalculateWorldMatrixAt = function makeCalculateWor
  * or undefined if no transform is associated.
  *
  * @method
- * 
+ *
  * @param {String} path The path to lookup
  *
  * @return {Transform | undefined} the transform at that path is available, else undefined.
@@ -145,7 +147,7 @@ TransformSystem.prototype.update = function update () {
     var components;
 
     for (var i = 0, len = transforms.length ; i < len ; i++) {
-        node = Dispatch.getNode(paths[i]);
+        node = this._dispatch.getNode(paths[i]);
         if (!node) continue;
         components = node.getComponents();
         transform = transforms[i];
@@ -372,4 +374,4 @@ function worldTransformChanged (node, components, transform) {
             components[i].onWorldTransformChange(transform);
 }
 
-module.exports = new TransformSystem();
+module.exports = TransformSystem;

--- a/core/test/dispatch/Dispatch.spec.js
+++ b/core/test/dispatch/Dispatch.spec.js
@@ -10,60 +10,54 @@ var test = require('tape');
 Dispatch.__set__('PathUtils', PathUtilsStub);
 
 test('Dispatch singleton', function (t) {
-
-    t.test('Dispatch object', function (t) {
-
-        t.test('Dispatch should exist as a module', function (t) {
-            t.equal(typeof Dispatch, 'object', 'Dispatch should be an object');
-            t.end();
-        });
+    
+    t.test('Dispatch should conform to its public api', function (t) {
         
-        t.test('Dispatch should conform to its public api', function (t) {
+        var dispatch = new Dispatch();
 
-            api.forEach(function (method) {
-                t.ok(Dispatch[method], 'Dispatch should have a ' +
-                                        method + ' method');
+        api.forEach(function (method) {
+            
+            t.ok(dispatch[method], 'dispatch should have a ' +
+                                    method + ' method');
 
-                t.equal(Dispatch[method].constructor, Function, 'Dispatch.'
-                                                     + method + ' should be a function');
-            });
-
-            t.end();
+            t.equal(dispatch[method].constructor, Function, 'dispatch.'
+                                                 + method + ' should be a function');
         });
 
         t.end();
     });
 
     t.test('._setUpdater method', function (t) {
+        var dispatch = new Dispatch();
 
         var testUpdater = 'a';
         
         t.doesNotThrow(
-            Dispatch._setUpdater.bind(Dispatch, testUpdater), 
+            dispatch._setUpdater.bind(dispatch, testUpdater),
             '._setUpdater should be callable'
         );
 
         var stub = new NodeStub();
 
-        Dispatch.mount('body', stub);
+        dispatch.mount('body', stub);
 
-        t.ok(stub._setUpdater.getCall(0).calledWith(testUpdater), 'Nodes mounted with the Dispatch ' +
+        t.ok(stub._setUpdater.getCall(0).calledWith(testUpdater), 'Nodes mounted with the dispatch ' +
                                                                   'should have their updaters set to ' +
                                                                   'the dispatch\'s updater');
 
         var testUpdater2 = 'b';
 
-        Dispatch._setUpdater(testUpdater2);
+        dispatch._setUpdater(testUpdater2);
 
         var stub2 = new NodeStub();
 
-        Dispatch.mount('body/0', stub2);
+        dispatch.mount('body/0', stub2);
 
         t.notOk(stub2._setUpdater.getCall(0).calledWith(testUpdater), 'Nodes mounted with the Dispatch ' +
-                                                                      'should have their updaters set to ' + 
+                                                                      'should have their updaters set to ' +
                                                                       'the dispatch\'s current updater and not a previous one');
 
-        t.ok(stub2._setUpdater.getCall(0).calledWith(testUpdater2), 'Nodes mounted with the Dispatch ' + 
+        t.ok(stub2._setUpdater.getCall(0).calledWith(testUpdater2), 'Nodes mounted with the Dispatch ' +
                                                                     'should have their updaters set to ' +
                                                                     'the dispatch\'s current updater');
 

--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -25,7 +25,6 @@
 'use strict';
 
 var CallbackStore = require('../utilities/CallbackStore');
-var TransformSystem = require('../core/TransformSystem');
 var Commands = require('../core/Commands');
 var Size = require('../core/Size');
 
@@ -169,7 +168,7 @@ DOMElement.prototype.onMount = function onMount(node, id) {
     this._node = node;
     this._id = id;
     this._UIEvents = node.getUIEvents().slice(0);
-    TransformSystem.makeBreakPointAt(node.getLocation());
+    node._transformSystem.makeBreakPointAt(node.getLocation());
     this.onSizeModeChange.apply(this, node.getSizeMode());
     this.draw();
     this.setAttribute('data-fa-path', node.getLocation());
@@ -466,7 +465,7 @@ DOMElement.prototype._requestUpdate = function _requestUpdate() {
 DOMElement.prototype.init = function init () {
     this._changeQueue.push(Commands.INIT_DOM, this._tagName);
     this._initialized = true;
-    this.onTransformChange(TransformSystem.get(this._node.getLocation()));
+    this.onTransformChange(this._node._updater._transformSystem.get(this._node.getLocation()));
     var size = this._node.getSize();
     this.onSizeChange(size[0], size[1]);
     if (!this._requestingUpdate) this._requestUpdate();

--- a/webgl-renderables/Mesh.js
+++ b/webgl-renderables/Mesh.js
@@ -25,7 +25,6 @@
 'use strict';
 var Geometry = require('../webgl-geometries');
 var Commands = require('../core/Commands');
-var TransformSystem = require('../core/TransformSystem');
 var defaultGeometry = new Geometry.Plane();
 
 /**
@@ -495,7 +494,7 @@ Mesh.prototype.onMount = function onMount (node, id) {
     this._node = node;
     this._id = id;
 
-    TransformSystem.makeCalculateWorldMatrixAt(node.getLocation());
+    this._node._transformSystem.makeCalculateWorldMatrixAt(node.getLocation());
 
     this.draw();
 };
@@ -638,7 +637,7 @@ Mesh.prototype._requestUpdate = function _requestUpdate () {
  */
 Mesh.prototype.init = function init () {
     this._initialized = true;
-    this.onTransformChange(TransformSystem.get(this._node.getLocation()));
+    this.onTransformChange(this._node._transformSystem.get(this._node.getLocation()));
     var size = this._node.getSize();
     this.onSizeChange(size[0], size[1], size[2]);
     this.onOpacityChange(this._node.getOpacity());

--- a/webgl-renderables/lights/PointLight.js
+++ b/webgl-renderables/lights/PointLight.js
@@ -25,7 +25,6 @@
 'use strict';
 
 var Light = require('./Light');
-var TransformSystem = require('../../core/TransformSystem');
 
 /**
  * PointLight extends the functionality of Light. PointLight is a light source
@@ -63,8 +62,8 @@ PointLight.prototype.constructor = PointLight;
  */
 PointLight.prototype.onMount = function onMount(node, id) {
     this._id = id;
-    TransformSystem.makeBreakPointAt(this._node.getLocation());
-    this.onTransformChange(TransformSystem.get(this._node.getLocation()));
+    this._node._transformSystem.makeBreakPointAt(this._node.getLocation());
+    this.onTransformChange(this._node._transformSystem.get(this._node.getLocation()));
 };
 
 /**


### PR DESCRIPTION
As discussed on Slack.

Probably needs some more testing. Currently there are basically no tests for Node and Dispatch. Not sure if they should be tested here or in a separate PR.

Also the systems inherit from PathStore now (maybe rename it to System?). That way there is much less redundancy.