### PR TITLE
fix: Set DOMElement#_node before _requestUpdate

### DIFF
--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -72,8 +72,8 @@ function DOMElement(node, options) {
     this._tagName = options && options.tagName ? options.tagName : 'div';
     this._renderSize = [0, 0, 0];
 
-    this._id = node ? node.addComponent(this) : null;
     this._node = node;
+    this._id = node ? node.addComponent(this) : null;
 
     this._callbacks = new CallbackStore();
 
@@ -449,7 +449,7 @@ DOMElement.prototype.getRenderSize = function getRenderSize() {
  * @return {undefined} undefined
  */
 DOMElement.prototype._requestUpdate = function _requestUpdate() {
-    if (!this._requestingUpdate) {
+    if (!this._requestingUpdate && this._id) {
         this._node.requestUpdate(this._id);
         this._requestingUpdate = true;
     }

--- a/dom-renderables/DOMElement.js
+++ b/dom-renderables/DOMElement.js
@@ -73,7 +73,7 @@ function DOMElement(node, options) {
     this._renderSize = [0, 0, 0];
 
     this._node = node;
-    this._id = node ? node.addComponent(this) : null;
+    if (node) node.addComponent(this);
 
     this._callbacks = new CallbackStore();
 


### PR DESCRIPTION
Fixes a bug where the initial update is being requested before a
node is available.

@michaelobriena Please merge as soon as possible if possible. This is a pretty serious bug.

The issue is that `DOMElement#onShow` results into a `DOMElement#_requestUpdate`, which requires `DOMElement#_node` to be set. `DOMElement#onShow` is being called in `Node#addComponent`:

```js
Node.prototype.addComponent = function addComponent (component) {
    var index = this._components.indexOf(component);
    if (index === -1) {
        index = this._freedComponentIndicies.length ? this._freedComponentIndicies.pop() : this._components.length;
        this._components[index] = component;

        if (this.isMounted() && component.onMount)
            component.onMount(this, index);

        if (this.isShown() && component.onShow)
            component.onShow();
    }

    return index;
};
```