### PR TITLE
fix: Get context size from DOMRenderer root element size

### DIFF
--- a/renderers/Context.js
+++ b/renderers/Context.js
@@ -220,8 +220,8 @@ Context.prototype._initWebGLRenderer = function _initWebGLRenderer() {
  */
 Context.prototype.getRootSize = function getRootSize() {
     return [
-        this._rootEl.offsetWidth,
-        this._rootEl.offsetHeight
+        this._domRendererRootEl.offsetWidth,
+        this._domRendererRootEl.offsetHeight
     ];
 };
 


### PR DESCRIPTION
#411 

Still not sure if we actually want this or if we should just assume that the selected element is "clean", since e.g. the DOMRenderer root element could also be styled via CSS etc.

I don't think it's a big issue (if any).