### PR TITLE
refact: Reduce redundancy in WebGLRenderer

### DIFF
--- a/utilities/Registry.js
+++ b/utilities/Registry.js
@@ -1,0 +1,57 @@
+'use strict';
+
+function Registry () {
+    this._keyToValue = {};
+    this._values = [];
+    this._keys = [];
+    this._keyToIndex = {};
+    this._freedIndices = [];
+}
+
+Registry.prototype.register = function register (key, value) {
+    var index = this._keyToIndex[key];
+    if (index == null) {
+        index = this._freedIndices.pop();
+        if (index === undefined) index = this._values.length;
+
+        this._values[index] = value;
+        this._keys[index] = key;
+
+        this._keyToIndex[key] = index;
+        this._keyToValue[key] = value;
+    }
+    else {
+        this._keyToValue[key] = value;
+        this._values[index] = value;
+    }
+};
+
+Registry.prototype.unregister = function unregister (key) {
+    var index = this._keyToIndex[key];
+
+    if (index != null) {
+        this._freedIndices.push(index);
+        this._keyToValue[key] = null;
+        this._keyToIndex[key] = null;
+        this._values[index] = null;
+        this._keys[index] = null;
+    }
+};
+
+Registry.prototype.get = function get (key) {
+    return this._keyToValue[key];
+};
+
+Registry.prototype.getValues = function getValues () {
+    return this._values;
+};
+
+Registry.prototype.getKeys = function getKeys () {
+    return this._keys;
+};
+
+Registry.prototype.getKeyToValue = function getKeyToValue () {
+    return this._keyToValue;
+};
+
+module.exports = Registry;

--- a/utilities/index.js
+++ b/utilities/index.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,7 +33,7 @@ module.exports = {
     keyValueToArrays: require('./keyValueToArrays'),
     loadURL: require('./loadURL'),
     ObjectManager: require('./ObjectManager'),
+    Registry: require('./Registry'),
     strip: require('./strip'),
     vendorPrefix: require('./vendorPrefix')
 };
-

--- a/webgl-renderers/Program.js
+++ b/webgl-renderers/Program.js
@@ -121,7 +121,7 @@ function Program(gl, options) {
     this.options = options || {};
 
     this.registeredMaterials = {};
-    this.cachedUniforms  = {};
+    this.cachedUniforms = {};
     this.uniformTypes = [];
 
     this.definitionVec4 = [];
@@ -400,12 +400,10 @@ Program.prototype.setUniforms = function (uniformNames, uniformValue) {
 
         // Check if the value is already set for the
         // given uniform.
-
         if (this.uniformIsCached(name, value)) continue;
 
         // Determine the correct function and pass the uniform
         // value to WebGL.
-
         if (!this.uniformTypes[name]) {
             this.uniformTypes[name] = this.getUniformTypeFromValue(value);
         }
@@ -413,11 +411,11 @@ Program.prototype.setUniforms = function (uniformNames, uniformValue) {
         // Call uniform setter function on WebGL context with correct value
 
         switch (this.uniformTypes[name]) {
-            case 'uniform4fv':  gl.uniform4fv(location, value); break;
-            case 'uniform3fv':  gl.uniform3fv(location, value); break;
-            case 'uniform2fv':  gl.uniform2fv(location, value); break;
-            case 'uniform1fv':  gl.uniform1fv(location, value); break;
-            case 'uniform1f' :  gl.uniform1f(location, value); break;
+            case 'uniform4fv': gl.uniform4fv(location, value); break;
+            case 'uniform3fv': gl.uniform3fv(location, value); break;
+            case 'uniform2fv': gl.uniform2fv(location, value); break;
+            case 'uniform1fv': gl.uniform1fv(location, value); break;
+            case 'uniform1f' : gl.uniform1f(location, value); break;
             case 'uniformMatrix3fv': gl.uniformMatrix3fv(location, false, value); break;
             case 'uniformMatrix4fv': gl.uniformMatrix4fv(location, false, value); break;
         }


### PR DESCRIPTION
Implements a "Registry" class to avoid having to manually keep track of the
stored values in a separate array. As a side effect, this also optimizes the
process of deregistering objects (especially meshes, where Array#splice has
been used before). In the future, the registry could also be used for storing
child nodes.