### PR TITLE
refact: Throw error when using FamousEngine#init in a web worker

### DIFF
--- a/core/FamousEngine.js
+++ b/core/FamousEngine.js
@@ -94,6 +94,12 @@ function FamousEngine() {
  * @return {FamousEngine} this
  */
 FamousEngine.prototype.init = function init(options) {
+    if (typeof window === 'undefined') {
+        throw new Error(
+            'FamousEngine#init needs to have access to the global window object. ' +
+            'Instantiate Compositor and UIManager manually in the UI thread.'
+        );
+    }
     this.compositor = options && options.compositor || new Compositor();
     this.renderLoop = options && options.renderLoop || new RequestAnimationFrameLoop();
     this.uiManager = new UIManager(this.getChannel(), this.compositor, this.renderLoop);


### PR DESCRIPTION
FamousEngine#init can only be used when we have access to the global window
object. We should throw an error in that case to avoid obscure stack traces.