### PR TITLE
refact: Remove obsolete data clone

### DIFF
--- a/webgl-renderers/Buffer.js
+++ b/webgl-renderers/Buffer.js
@@ -56,15 +56,9 @@ function Buffer(target, type, gl) {
  */
 Buffer.prototype.subData = function subData() {
     var gl = this.gl;
-    var data = [];
-
-    // to prevent against maximum call-stack issue.
-    for (var i = 0, chunk = 10000; i < this.data.length; i += chunk)
-        data = Array.prototype.concat.apply(data, this.data.slice(i, i + chunk));
-
     this.buffer = this.buffer || gl.createBuffer();
     gl.bindBuffer(this.target, this.buffer);
-    gl.bufferData(this.target, new this.type(data), gl.STATIC_DRAW);
+    gl.bufferData(this.target, new this.type(this.data), gl.STATIC_DRAW);
 };
 
 module.exports = Buffer;


### PR DESCRIPTION
In the current implementation a new typed array is being instantiated on
every subData call using `concat`. This should be factored out by sending
the data as a transferable ArrayBuffer through postMessage, resulting
into a zero-copy transfer. For the time being, we can at least remove the
obsolete cloning of the array using concat.

@michaelobriena Is there a case in which `this.data` is nested (I couldn't come up with one, but I'm not sure)? If that's the case the proposed solution wouldn't work.