### PR TITLE
fix: Don't use sparse arrays for radixSort

### DIFF
--- a/webgl-renderers/radixSort.js
+++ b/webgl-renderers/radixSort.js
@@ -107,7 +107,7 @@ function radixSort(list, registry) {
             div = floatToInt(comp(list, registry, i));
             out[++buckets[div & radixMask]] = mutator(list, registry, i, div ^= div >> 31 | 0x80000000);
         }
-        
+
         swap = out;
         out = list;
         list = swap;

--- a/webgl-renderers/test/radixSort.spec.js
+++ b/webgl-renderers/test/radixSort.spec.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,28 +27,27 @@ var test = require('tape');
 var radixSort = require('../radixSort');
 
 test('radixSort', function(t) {
-    var registry = {};
-    var meshList = [];
-    while (meshList.length < 1e3) {
-        var path = Math.random();
-        registry[path] = mockMesh();
-        meshList[meshList.length] = path;
-    }
 
-    radixSort(meshList, registry);
+    t.test('dense array', function(t) {
+        var registry = {};
+        var meshList = [];
+        while (meshList.length < 1e3) {
+            var path = Math.random();
+            registry[path] = mockMesh();
+            meshList[meshList.length] = path;
+        }
 
-    t.test('sort', function(t) {
-        t.equals(checkSorted(meshList), true, 'should be sorted by depth');
+        radixSort(meshList, registry);
 
+        t.ok(checkSorted(meshList), 'should be sorted by depth');
         t.end();
     });
 
-    t.end();
 });
 
 function checkSorted (list, registry){
     var a, b;
-    for (var i= 0; i < test.length - 1; i++) {
+    for (var i = 0; i < test.length - 1; i++) {
         a = list[i].uniformValues[1][14];
         b = list[i+1].uniformValues[1][14];
         if (a < b)  return false;


### PR DESCRIPTION
Previously this wasn't an issue, since:

1. There were no registries
2. Meshes were never being removed

radixSort only works with dense arrays. Therefore the Registry class can't be used for keeping track of meshes.