### PR TITLE
refact: No longer double vertices in GeometryHelper.addBackfaceTriangles

### DIFF
--- a/webgl-geometries/GeometryHelper.js
+++ b/webgl-geometries/GeometryHelper.js
@@ -528,39 +528,18 @@ GeometryHelper.trianglesToLines = function triangleToLines(indices, out) {
 };
 
 /**
- * Adds a reverse order triangle for every triangle in the mesh. Adds extra vertices
- * and indices to input arrays.
+ * Adds a reverse order triangle for every triangle in the mesh. Adds extra
+ * indices to input array.
  *
  * @static
  * @method
  *
- * @param {Array} vertices X, Y, Z positions of all vertices in the geometry
  * @param {Array} indices Indices of all faces on the geometry
  * @return {undefined} undefined
  */
-GeometryHelper.addBackfaceTriangles = function addBackfaceTriangles(vertices, indices) {
-    var nFaces = indices.length / 3;
-
-    var maxIndex = 0;
-    var i = indices.length;
-    while (i--) if (indices[i] > maxIndex) maxIndex = indices[i];
-
-    maxIndex++;
-
-    for (i = 0; i < nFaces; i++) {
-        var indexOne = indices[i * 3],
-            indexTwo = indices[i * 3 + 1],
-            indexThree = indices[i * 3 + 2];
-
-        indices.push(indexOne + maxIndex, indexThree + maxIndex, indexTwo + maxIndex);
-    }
-
-    // Iterating instead of .slice() here to avoid max call stack issue.
-
-    var nVerts = vertices.length;
-    for (i = 0; i < nVerts; i++) {
-        vertices.push(vertices[i]);
-    }
+GeometryHelper.addBackfaceTriangles = function addBackfaceTriangles(indices) {
+    for (var face = 0, len = indices.length; face < len; face += 3)
+        indices.push(indices[face], indices[face + 2], indices[face + 1]);
 };
 
 module.exports = GeometryHelper;

--- a/webgl-geometries/primitives/Circle.js
+++ b/webgl-geometries/primitives/Circle.js
@@ -44,9 +44,8 @@ function Circle (options) {
     var detail   = options.detail || 30;
     var buffers  = getCircleBuffers(detail, true);
 
-    if (options.backface !== false) {
-        GeometryHelper.addBackfaceTriangles(buffers.vertices, buffers.indices);
-    }
+    if (options.backface !== false)
+        GeometryHelper.addBackfaceTriangles(buffers.indices);
 
     var textureCoords = getCircleTexCoords(buffers.vertices);
     var normals = GeometryHelper.computeNormals(buffers.vertices, buffers.indices);

--- a/webgl-geometries/primitives/Cylinder.js
+++ b/webgl-geometries/primitives/Cylinder.js
@@ -52,9 +52,8 @@ function Cylinder (options) {
         Cylinder.generator.bind(null, radius)
     );
 
-    if (options.backface !== false) {
-        GeometryHelper.addBackfaceTriangles(buffers.vertices, buffers.indices);
-    }
+    if (options.backface !== false)
+        GeometryHelper.addBackfaceTriangles(buffers.indices);
 
     options.buffers = [
         { name: 'a_pos', data: buffers.vertices },

--- a/webgl-geometries/primitives/ParametricCone.js
+++ b/webgl-geometries/primitives/ParametricCone.js
@@ -50,9 +50,8 @@ function ParametricCone (options) {
         ParametricCone.generator.bind(null, radius)
     );
 
-    if (options.backface !== false) {
-        GeometryHelper.addBackfaceTriangles(buffers.vertices, buffers.indices);
-    }
+    if (options.backface !== false)
+        GeometryHelper.addBackfaceTriangles(buffers.indices);
 
     options.buffers = [
         { name: 'a_pos', data: buffers.vertices },

--- a/webgl-geometries/primitives/Plane.js
+++ b/webgl-geometries/primitives/Plane.js
@@ -66,10 +66,9 @@ function Plane(options) {
     }
 
     if (options.backface !== false) {
-        GeometryHelper.addBackfaceTriangles(vertices, indices);
+        GeometryHelper.addBackfaceTriangles(indices);
 
         // duplicate texture coordinates as well
-
         var len = textureCoords.length;
         for (i = 0; i < len; i++) textureCoords.push(textureCoords[i]);
     }

--- a/webgl-geometries/primitives/Triangle.js
+++ b/webgl-geometries/primitives/Triangle.js
@@ -59,9 +59,8 @@ function Triangle (options) {
 
     while(--detail) GeometryHelper.subdivide(indices, vertices, textureCoords);
 
-    if (options.backface !== false) {
-        GeometryHelper.addBackfaceTriangles(vertices, indices);
-    }
+    if (options.backface !== false)
+        GeometryHelper.addBackfaceTriangles(indices);
 
     normals = GeometryHelper.computeNormals(vertices, indices);
 


### PR DESCRIPTION
The vertices can be reused, only the corresponding indices need to
be duplicated.