### PR TITLE
refact: Refactor geometries

### DIFF
--- a/renderers/Compositor.js
+++ b/renderers/Compositor.js
@@ -270,7 +270,8 @@ Compositor.prototype.giveSizeFor = function giveSizeFor(iterator, commands) {
     if (context) {
         var size = context.getRootSize();
         this.sendResize(selector, size);
-    } else {
+    }
+    else {
         this.getOrSetContext(selector);
     }
 };

--- a/webgl-geometries/Geometry.js
+++ b/webgl-geometries/Geometry.js
@@ -52,11 +52,11 @@ function Geometry(options) {
 
     if (this.options.buffers) {
         var len = this.options.buffers.length;
-        for (var i = 0; i < len;) {
+        for (var i = 0; i < len; i++) {
             this.spec.bufferNames.push(this.options.buffers[i].name);
             this.spec.bufferValues.push(this.options.buffers[i].data);
             this.spec.bufferSpacings.push(this.options.buffers[i].size || this.DEFAULT_BUFFER_SIZE);
-            this.spec.invalidations.push(i++);
+            this.spec.invalidations.push(i);
         }
     }
 }

--- a/webgl-geometries/primitives/Box.js
+++ b/webgl-geometries/primitives/Box.js
@@ -52,6 +52,8 @@ var boxData = [
  * @return {Object} constructed geometry
  */
 function BoxGeometry(options) {
+    if (!(this instanceof BoxGeometry)) return new BoxGeometry(options);
+
     options = options || {};
 
     var vertices      = [];
@@ -87,7 +89,10 @@ function BoxGeometry(options) {
         { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+BoxGeometry.prototype = Object.create(Geometry.prototype);
+BoxGeometry.prototype.constructor = BoxGeometry;
 
 module.exports = BoxGeometry;

--- a/webgl-geometries/primitives/Circle.js
+++ b/webgl-geometries/primitives/Circle.js
@@ -40,6 +40,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function Circle (options) {
+    if (!(this instanceof Circle)) return new Circle(options);
+
     options  = options || {};
     var detail   = options.detail || 30;
     var buffers  = getCircleBuffers(detail, true);
@@ -58,8 +60,11 @@ function Circle (options) {
         { name: 'indices', data: buffers.indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Circle.prototype = Object.create(Geometry.prototype);
+Circle.prototype.constructor = Circle;
 
 function getCircleTexCoords (vertices) {
     var textureCoords = [];

--- a/webgl-geometries/primitives/Cylinder.js
+++ b/webgl-geometries/primitives/Cylinder.js
@@ -41,6 +41,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function Cylinder (options) {
+    if (!(this instanceof Cylinder)) return new Cylinder(options);
+
     options  = options || {};
     var radius   = options.radius || 1;
     var detail   = options.detail || 15;
@@ -63,8 +65,11 @@ function Cylinder (options) {
         { name: 'indices', data: buffers.indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Cylinder.prototype = Object.create(Geometry.prototype);
+Cylinder.prototype.constructor = Cylinder;
 
 /**
  * Function used in iterative construction of parametric primitive.

--- a/webgl-geometries/primitives/GeodesicSphere.js
+++ b/webgl-geometries/primitives/GeodesicSphere.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,10 +36,12 @@ var GeometryHelper = require('../GeometryHelper');
  *
  * @param {Object} options Parameters that alter the
  * vertex buffers of the generated geometry.
- * 
+ *
  * @return {Object} constructed geometry
  */
 function GeodesicSphere (options) {
+    if (!(this instanceof GeodesicSphere)) return new GeodesicSphere(options);
+
     var t = (1 + Math.sqrt(5)) * 0.5;
 
     var vertices = [
@@ -72,7 +74,10 @@ function GeodesicSphere (options) {
         { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+GeodesicSphere.prototype = Object.create(Geometry.prototype);
+GeodesicSphere.prototype.constructor = GeodesicSphere;
 
 module.exports = GeodesicSphere;

--- a/webgl-geometries/primitives/Icosahedron.js
+++ b/webgl-geometries/primitives/Icosahedron.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2015 Famous Industries Inc.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,12 +36,13 @@ var GeometryHelper = require('../GeometryHelper');
  *
  * @param {Object} options Parameters that alter the
  * vertex buffers of the generated geometry.
- * 
+ *
  * @return {Object} constructed geometry
  */
-function Icosahedron( options )
-{
-   options = options || {};
+function Icosahedron(options) {
+    if (!(this instanceof Icosahedron)) return new Icosahedron(options);
+
+    options = options || {};
     var t = ( 1 + Math.sqrt( 5 ) ) / 2;
 
     var vertices = [
@@ -70,7 +71,10 @@ function Icosahedron( options )
         { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Icosahedron.prototype = Object.create(Geometry.prototype);
+Icosahedron.prototype.constructor = Icosahedron;
 
 module.exports = Icosahedron;

--- a/webgl-geometries/primitives/ParametricCone.js
+++ b/webgl-geometries/primitives/ParametricCone.js
@@ -40,7 +40,9 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function ParametricCone (options) {
-    options  = options || {};
+    if (!(this instanceof ParametricCone)) return new ParametricCone(options);
+
+    options = options || {};
     var detail   = options.detail || 15;
     var radius   = options.radius || 1 / Math.PI;
 
@@ -61,8 +63,11 @@ function ParametricCone (options) {
         { name: 'indices', data: buffers.indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+ParametricCone.prototype = Object.create(Geometry.prototype);
+ParametricCone.prototype.constructor = ParametricCone;
 
 /**
  * function used in iterative construction of parametric primitive.

--- a/webgl-geometries/primitives/Plane.js
+++ b/webgl-geometries/primitives/Plane.js
@@ -40,6 +40,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function Plane(options) {
+    if (!(this instanceof Plane)) return new Plane(options);
+
     options = options || {};
     var detailX = options.detailX || options.detail || 1;
     var detailY = options.detailY || options.detail || 1;
@@ -83,7 +85,10 @@ function Plane(options) {
         { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Plane.prototype = Object.create(Geometry.prototype);
+Plane.prototype.constructor = Plane;
 
 module.exports = Plane;

--- a/webgl-geometries/primitives/Sphere.js
+++ b/webgl-geometries/primitives/Sphere.js
@@ -40,6 +40,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function ParametricSphere (options) {
+    if (!(this instanceof ParametricSphere)) return new ParametricSphere(options);
+
     options = options || {};
     var detail = options.detail || 10;
     var detailX = options.detailX || detail;
@@ -59,8 +61,11 @@ function ParametricSphere (options) {
         { name: 'indices', data: buffers.indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+ParametricSphere.prototype = Object.create(Geometry.prototype);
+ParametricSphere.prototype.constructor = ParametricSphere;
 
 /**
  * Function used in iterative construction of parametric primitive.

--- a/webgl-geometries/primitives/Tetrahedron.js
+++ b/webgl-geometries/primitives/Tetrahedron.js
@@ -40,6 +40,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function Tetrahedron(options) {
+    if (!(this instanceof Tetrahedron)) return new Tetrahedron(options);
+
     var textureCoords = [];
     var normals = [];
     var detail;
@@ -95,7 +97,10 @@ function Tetrahedron(options) {
         { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Tetrahedron.prototype = Object.create(Geometry.prototype);
+Tetrahedron.prototype.constructor = Tetrahedron;
 
 module.exports = Tetrahedron;

--- a/webgl-geometries/primitives/Torus.js
+++ b/webgl-geometries/primitives/Torus.js
@@ -41,8 +41,10 @@ var GeometryHelper = require('../GeometryHelper');
  */
 
 function Torus(options) {
-    options  = options || {};
-    var detail   = options.detail || 30;
+    if (!(this instanceof Torus)) return new Torus(options);
+
+    options = options || {};
+    var detail = options.detail || 30;
     var holeRadius = options.holeRadius || 0.80;
     var tubeRadius = options.tubeRadius || 0.20;
 
@@ -59,8 +61,11 @@ function Torus(options) {
         { name: 'indices', data: buffers.indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Torus.prototype = Object.create(Geometry.prototype);
+Torus.prototype.constructor = Torus;
 
 /**
  * function used in iterative construction of parametric primitive.

--- a/webgl-geometries/primitives/Triangle.js
+++ b/webgl-geometries/primitives/Triangle.js
@@ -40,6 +40,8 @@ var GeometryHelper = require('../GeometryHelper');
  * @return {Object} constructed geometry
  */
 function Triangle (options) {
+    if (!(this instanceof Triangle)) return new Triangle(options);
+
     options  = options || {};
     var detail   = options.detail || 1;
     var normals  = [];
@@ -57,11 +59,10 @@ function Triangle (options) {
          1, -1, 0
     ];
 
-    while(--detail) GeometryHelper.subdivide(indices, vertices, textureCoords);
+    while (--detail) GeometryHelper.subdivide(indices, vertices, textureCoords);
 
-    if (options.backface !== false) {
+    if (options.backface !== false)
         GeometryHelper.addBackfaceTriangles(vertices, indices);
-    }
 
     normals = GeometryHelper.computeNormals(vertices, indices);
 
@@ -72,7 +73,10 @@ function Triangle (options) {
             { name: 'indices', data: indices, size: 1 }
     ];
 
-    return new Geometry(options);
+    Geometry.call(this, options);
 }
+
+Triangle.prototype = Object.create(Geometry.prototype);
+Triangle.prototype.constructor = Triangle;
 
 module.exports = Triangle;

--- a/webgl-geometries/test/Primitives.spec.js
+++ b/webgl-geometries/test/Primitives.spec.js
@@ -58,17 +58,18 @@ test('Primitives', function(t) {
         }
 		t.end();
     });
-    
+
     t.test('Primitives.optionsParameter', function(t) {
         for (var name in primitives) {
             var primitive = new primitives[name]({type:'POINTS'});
 
             t.ok(primitive instanceof Geometry, 'should be an instance of a static geometry');
+            t.ok(primitive instanceof primitives[name], 'should be an instance of its constructor function');
 
             t.notEquals(primitive.spec.bufferNames.indexOf('a_texCoord'), -1, 'should contain a texCoord buffer');
             t.notEquals(primitive.spec.bufferNames.indexOf('a_normals'), -1, 'should contain a normal buffer');
             t.notEquals(primitive.spec.bufferNames.indexOf('a_pos'), -1, 'should contain a pos buffer');
-            
+
             t.equals(primitive.spec.type, 'POINTS', 'draw type should be passed through');
 
             if (name !== 'Circle') {
@@ -77,8 +78,7 @@ test('Primitives', function(t) {
         }
 		t.end();
     });
-    
+
 
     t.end();
 });
-

--- a/webgl-renderables/Mesh.js
+++ b/webgl-renderables/Mesh.js
@@ -23,10 +23,14 @@
  */
 
 'use strict';
+
+// TODO This will be removed once `Mesh#setGeometry` no longer accepts
+// geometries defined by name.
 var Geometry = require('../webgl-geometries');
+
 var Commands = require('../core/Commands');
 var TransformSystem = require('../core/TransformSystem');
-var defaultGeometry = new Geometry.Plane();
+var Plane = require('../webgl-geometries/primitives/Plane');
 
 /**
  * The Mesh class is responsible for providing the API for how
@@ -53,7 +57,7 @@ function Mesh (node, options) {
     this._requestingUpdate = false;
     this._inDraw = false;
     this.value = {
-        geometry: defaultGeometry,
+        geometry: Plane(),
         drawOptions: null,
         color: null,
         expressions: {},
@@ -108,7 +112,15 @@ Mesh.prototype.getDrawOptions = function getDrawOptions () {
 Mesh.prototype.setGeometry = function setGeometry (geometry, options) {
     if (typeof geometry === 'string') {
         if (!Geometry[geometry]) throw 'Invalid geometry: "' + geometry + '".';
-        else geometry = new Geometry[geometry](options);
+        else {
+            console.warn(
+                'Mesh#setGeometry using the geometry registry is deprecated!\n' +
+                'Instantiate the geometry directly via `new ' + geometry +
+                '(options)` instead!'
+            );
+
+            geometry = new Geometry[geometry](options);
+        }
     }
 
     if (this.value.geometry !== geometry || this._inDraw) {


### PR DESCRIPTION
This refactor solves a number of issues ans subtle bugs that are
present in the current implementation. No breaking changes have
been made.

* Usage of defaultGeometry: Previously a single defaultGeometry has
  been used for all Meshes that didn't have a geometry set on them.
  Since it was possible to retrieve and mutate the geometry, mutating
  the geometry of one Mesh would have resulted into unexpected
  results (since the geometry was shared among all Meshes).

* Primitives inherit from Geometry: Although the methods were
  documented as constructors, they actually instantiated a new
  Geometry and returned it. This resulted into confusing
  `instanceof` and `constructor` checks. The new keyword is still
  optional, there this is not a breaking change.

* Deprecate Mesh#setGeometry's geometry register: Accepting
  geometries as strings is problematic, since it means that **all**
  geometries will be required and included in the bundled file (as
  pointed out on phabricator). Currently a console.warn is used for
  printing the deprecation notice.