### PR TITLE
fix: Properly update position in callback function

### DIFF
--- a/components/Position.js
+++ b/components/Position.js
@@ -158,8 +158,8 @@ Position.prototype._checkUpdate = function _checkUpdate() {
  * @return {undefined} undefined
  */
 Position.prototype.update = function update () {
-    this._node.setPosition(this._x.get(), this._y.get(), this._z.get());
     this._checkUpdate();
+    this._node.setPosition(this._x.get(), this._y.get(), this._z.get());
 };
 
 Position.prototype.onUpdate = Position.prototype.update;


### PR DESCRIPTION
Resolves #474

Example:

```
var position = new Position(parent0);
position.set(100, 100, 100, {
    duration: 500,
    curve: 'inOutExpo'
}, function () {
    position.set(0, 0, 0);
});
```
