### PR TITLE
chore: Update outdated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
   "author": "Famous",
   "license": "MIT",
   "devDependencies": {
-    "browserify": "^10.2.1",
+    "browserify": "^11.0.1",
     "colors": "^1.1.0",
-    "eslint": "^0.21.2",
+    "eslint": "^1.2.1",
     "glob": "^5.0.10",
     "istanbul": "^0.3.15",
     "rewire": "^2.3.3",
@@ -46,7 +46,7 @@
     "tap-closer": "^1.0.0",
     "tape": "^4.0.0",
     "tap-spec": "^4.0.0",
-    "uglify-js": "^2.4.17"
+    "uglify-js": "^2.4.24"
   },
   "dependencies": {
     "glslify": "^2.0.0"


### PR DESCRIPTION
See https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons

@michaelobriena
