### PR TITLE
Node cleanup convenience method

### DIFF
--- a/core/Node.js
+++ b/core/Node.js
@@ -1291,9 +1291,11 @@ Node.prototype.dismount = function dismount () {
  * Removes Node states to mask visibility in context switching
  * with optional context
  *
- * @method
+ * @method cleanup
  *
- * @return null
+ * @param {Object} [ctx] Optional context
+ *
+ * @returns {void}
  */
 Node.prototype.cleanup = function cleanup (ctx) {
     try {

--- a/core/Node.js
+++ b/core/Node.js
@@ -1287,4 +1287,31 @@ Node.prototype.dismount = function dismount () {
     if (!this._requestingUpdate) this._requestUpdate();
 };
 
-module.exports = Node;
+/**
+ * Removes Node states to mask visibility in context switching
+ * with optional context
+ *
+ * @method
+ *
+ * @return null
+ */
+Node.prototype.cleanup = function cleanup (ctx) {
+    try {
+        var was = this;
+        was._UIEvents.forEach(function(e) {
+            was.removeUIEvent(e);
+        });
+        was._components.forEach(function(c) {
+            c.setProperty('background-color', 'transparent')
+                .setContent('');
+            was.removeComponent(c);
+        });
+        was.setSizeMode('absolute', 'absolute')
+            .setAbsoluteSize(0, 0);
+        if (ctx) ctx.removeChild(was);
+    } catch(e) {
+        throw e
+    };
+};
+
+ module.exports = Node;

--- a/core/Node.js
+++ b/core/Node.js
@@ -1309,9 +1309,10 @@ Node.prototype.cleanup = function cleanup (ctx) {
         was.setSizeMode('absolute', 'absolute')
             .setAbsoluteSize(0, 0);
         if (ctx) ctx.removeChild(was);
-    } catch(e) {
-        throw e
-    };
+    } 
+    catch (e) {
+        throw e;
+    }
 };
 
  module.exports = Node;

--- a/core/Node.js
+++ b/core/Node.js
@@ -1288,8 +1288,8 @@ Node.prototype.dismount = function dismount () {
 };
 
 /**
- * Removes Node states to mask visibility in context switching
- * with optional context
+ * Removes selected Node visual states during context switching
+ * of parents creating new nodes, with optional context
  *
  * @method cleanup
  *


### PR DESCRIPTION
This utility came in handy during my own use case, specifically when switching parent nodes there would be remnants of previous nodes remaining on screen. I dunno whether others encountered this; figured to quickly jot down for feedback. Either there's an existing suggested procedure or there may be an utility for a convenience method.
